### PR TITLE
Add support for not-quite-es5 platforms?

### DIFF
--- a/src/bundler/builders/strictMode/amd.js
+++ b/src/bundler/builders/strictMode/amd.js
@@ -18,7 +18,7 @@ export default function amd ( bundle, body, options ) {
 
 	defaultsBlock = externalModules.map( x => {
 		var name = bundle.uniqueNames[ x.id ];
-		return indentStr + `var ${name}__default = ('default' in ${name} ? ${name}.default : ${name});`;
+		return indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 	}).join( '\n' );
 
 	if ( defaultsBlock ) {

--- a/src/bundler/builders/strictMode/cjs.js
+++ b/src/bundler/builders/strictMode/cjs.js
@@ -14,7 +14,7 @@ export default function cjs ( bundle, body, options ) {
 		var name = bundle.uniqueNames[ x.id ];
 
 		return indentStr + `var ${name} = require('${x.id}');\n` +
-		       indentStr + `var ${name}__default = ('default' in ${name} ? ${name}.default : ${name});`;
+		       indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 	}).join( '\n' );
 
 	if ( importBlock ) {

--- a/src/bundler/builders/strictMode/umd.js
+++ b/src/bundler/builders/strictMode/umd.js
@@ -25,7 +25,7 @@ export default function umd ( bundle, body, options ) {
 
 	defaultsBlock = bundle.externalModules.map( x => {
 		var name = bundle.uniqueNames[ x.id ];
-		return indentStr + `var ${name}__default = ('default' in ${name} ? ${name}.default : ${name});`;
+		return indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 	}).join( '\n' );
 
 	if ( defaultsBlock ) {

--- a/src/bundler/builders/strictMode/utils/getExportBlock.js
+++ b/src/bundler/builders/strictMode/utils/getExportBlock.js
@@ -9,7 +9,7 @@ export default function getExportBlock ( bundle, entry, indentStr ) {
 
 	// create an export block
 	if ( entry.defaultExport ) {
-		exportBlock = indentStr + 'exports.default = ' + name + '__default;';
+		exportBlock = indentStr + 'exports[\'default\'] = ' + name + '__default;';
 	}
 
 	entry.exports.forEach( x => {

--- a/src/standalone/builders/strictMode/utils/gatherImports.js
+++ b/src/standalone/builders/strictMode/utils/gatherImports.js
@@ -9,7 +9,15 @@ export default function gatherImports ( imports, getName, importedBindings, toRe
 				name = s.as;
 			}
 
-			replacement = s.batch ? s.name : ( getName( x ) + '.' + s.name );
+			if ( s.batch ) {
+				replacement = s.name;
+			} else {
+				if ( s.default ) {
+					replacement = getName( x ) + '[\'default\']';
+				} else {
+					replacement = getName( x ) + '.' + s.name;
+				}
+			}
 
 			importedBindings[ name ] = replacement;
 

--- a/src/standalone/builders/strictMode/utils/transformBody.js
+++ b/src/standalone/builders/strictMode/utils/transformBody.js
@@ -98,7 +98,7 @@ export default function transformBody ( mod, body, options ) {
 				if ( x.default ) {
 					// export default function answer () { return 42; }
 					defaultValue = body.slice( x.valueStart, x.end );
-					body.replace( x.start, x.end, defaultValue + '\nexports.default = ' + x.name + ';' );
+					body.replace( x.start, x.end, defaultValue + '\nexports[\'default\'] = ' + x.name + ';' );
 				} else {
 					// export function answer () { return 42; }
 					shouldExportEarly[ x.name ] = true; // TODO what about `function foo () {}; export { foo }`?
@@ -108,12 +108,12 @@ export default function transformBody ( mod, body, options ) {
 
 			case 'anonFunction':
 				// export default function () {}
-				body.replace( x.start, x.valueStart, 'exports.default = ' );
+				body.replace( x.start, x.valueStart, 'exports[\'default\'] = ' );
 				return;
 
 			case 'expression':
 				// export default 40 + 2;
-				body.replace( x.start, x.valueStart, 'exports.default = ' );
+				body.replace( x.start, x.valueStart, 'exports[\'default\'] = ' );
 				return;
 
 			case 'named':

--- a/test/bundle/output/amd/3.js
+++ b/test/bundle/output/amd/3.js
@@ -2,7 +2,7 @@ define(['external'], function (external) {
 
 	'use strict';
 
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var foo__bar = 'yes';
 	var foo__default = foo__bar;

--- a/test/bundle/output/amd/4.js
+++ b/test/bundle/output/amd/4.js
@@ -6,6 +6,6 @@ define(['exports'], function (exports) {
 
 	var main__default = foo__answer * 2;
 
-	exports.default = main__default;
+	exports['default'] = main__default;
 
 });

--- a/test/bundle/output/amd/6.js
+++ b/test/bundle/output/amd/6.js
@@ -2,7 +2,7 @@ define(['utils/external'], function (external) {
 
 	'use strict';
 
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var message__default = 'this is a message';
 

--- a/test/bundle/output/amd/8.js
+++ b/test/bundle/output/amd/8.js
@@ -2,6 +2,6 @@ define(['external'], function (ImplicitlyNamed) {
 
 	'use strict';
 
-	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed.default : ImplicitlyNamed);
+	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed);
 
 });

--- a/test/bundle/output/amd/9.js
+++ b/test/bundle/output/amd/9.js
@@ -2,6 +2,6 @@ define(['external'], function (Correct) {
 
 	'use strict';
 
-	var Correct__default = ('default' in Correct ? Correct.default : Correct);
+	var Correct__default = ('default' in Correct ? Correct['default'] : Correct);
 
 });

--- a/test/bundle/output/cjs/3.js
+++ b/test/bundle/output/cjs/3.js
@@ -3,7 +3,7 @@
 	'use strict';
 
 	var external = require('external');
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var foo__bar = 'yes';
 	var foo__default = foo__bar;

--- a/test/bundle/output/cjs/4.js
+++ b/test/bundle/output/cjs/4.js
@@ -6,6 +6,6 @@
 
 	var main__default = foo__answer * 2;
 
-	exports.default = main__default;
+	exports['default'] = main__default;
 
 }).call(global);

--- a/test/bundle/output/cjs/6.js
+++ b/test/bundle/output/cjs/6.js
@@ -3,7 +3,7 @@
 	'use strict';
 
 	var external = require('utils/external');
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var message__default = 'this is a message';
 

--- a/test/bundle/output/cjs/8.js
+++ b/test/bundle/output/cjs/8.js
@@ -3,6 +3,6 @@
 	'use strict';
 
 	var ImplicitlyNamed = require('external');
-	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed.default : ImplicitlyNamed);
+	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed);
 
 }).call(global);

--- a/test/bundle/output/cjs/9.js
+++ b/test/bundle/output/cjs/9.js
@@ -3,6 +3,6 @@
 	'use strict';
 
 	var Correct = require('external');
-	var Correct__default = ('default' in Correct ? Correct.default : Correct);
+	var Correct__default = ('default' in Correct ? Correct['default'] : Correct);
 
 }).call(global);

--- a/test/bundle/output/umd/3.js
+++ b/test/bundle/output/umd/3.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var foo__bar = 'yes';
 	var foo__default = foo__bar;

--- a/test/bundle/output/umd/4.js
+++ b/test/bundle/output/umd/4.js
@@ -22,6 +22,6 @@
 
 	var main__default = foo__answer * 2;
 
-	exports.default = main__default;
+	exports['default'] = main__default;
 
 }));

--- a/test/bundle/output/umd/6.js
+++ b/test/bundle/output/umd/6.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	var external__default = ('default' in external ? external.default : external);
+	var external__default = ('default' in external ? external['default'] : external);
 
 	var message__default = 'this is a message';
 

--- a/test/bundle/output/umd/8.js
+++ b/test/bundle/output/umd/8.js
@@ -18,6 +18,6 @@
 
 	'use strict';
 
-	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed.default : ImplicitlyNamed);
+	var ImplicitlyNamed__default = ('default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed);
 
 }));

--- a/test/bundle/output/umd/9.js
+++ b/test/bundle/output/umd/9.js
@@ -18,6 +18,6 @@
 
 	'use strict';
 
-	var Correct__default = ('default' in Correct ? Correct.default : Correct);
+	var Correct__default = ('default' in Correct ? Correct['default'] : Correct);
 
 }));

--- a/test/es6-module-transpiler-tests/output/cycles-defaults/a.js
+++ b/test/es6-module-transpiler-tests/output/cycles-defaults/a.js
@@ -6,6 +6,6 @@
 
 	/* jshint esnext:true */
 
-	exports.default = { a: 1, get b() { return b.default.b; } };
+	exports['default'] = { a: 1, get b() { return b['default'].b; } };
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/cycles-defaults/b.js
+++ b/test/es6-module-transpiler-tests/output/cycles-defaults/b.js
@@ -6,6 +6,6 @@
 
 	/* jshint esnext:true */
 
-	exports.default = { b: 2, get a() { return a.default.a; } };
+	exports['default'] = { b: 2, get a() { return a['default'].a; } };
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/cycles-defaults/importer.js
+++ b/test/es6-module-transpiler-tests/output/cycles-defaults/importer.js
@@ -7,9 +7,9 @@
 
 	/* jshint esnext:true */
 
-	assert.equal(a.default.a, 1);
-	assert.equal(a.default.b, 2);
-	assert.equal(b.default.a, 1);
-	assert.equal(b.default.b, 2);
+	assert.equal(a['default'].a, 1);
+	assert.equal(a['default'].b, 2);
+	assert.equal(b['default'].a, 1);
+	assert.equal(b['default'].b, 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/export-default-function/exporter.js
+++ b/test/es6-module-transpiler-tests/output/export-default-function/exporter.js
@@ -4,7 +4,7 @@
 
   /* jshint esnext:true */
 
-  exports.default = function () {
+  exports['default'] = function () {
     return 1;
   }
 

--- a/test/es6-module-transpiler-tests/output/export-default-function/importer.js
+++ b/test/es6-module-transpiler-tests/output/export-default-function/importer.js
@@ -7,7 +7,7 @@
 
 	/* jshint esnext:true */
 
-	assert.equal(fn1.default(), 1);
+	assert.equal(fn1['default'](), 1);
 	assert.equal(fn1.default(), 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/export-default-named-function/exporter.js
+++ b/test/es6-module-transpiler-tests/output/export-default-named-function/exporter.js
@@ -7,7 +7,7 @@
   function foo() {
     return 1;
   }
-  exports.default = foo;
+  exports['default'] = foo;
 
   function callsFoo() {
     return foo();

--- a/test/es6-module-transpiler-tests/output/export-default-named-function/importer.js
+++ b/test/es6-module-transpiler-tests/output/export-default-named-function/importer.js
@@ -4,7 +4,7 @@
 
 	var exporter = require('./exporter');
 
-	assert.strictEqual(exporter.default(), 1);
+	assert.strictEqual(exporter['default'](), 1);
 	assert.strictEqual(exporter.callsFoo(), 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/export-default/exporter.js
+++ b/test/es6-module-transpiler-tests/output/export-default/exporter.js
@@ -13,7 +13,7 @@
   }
 
   assert.equal(a, 42);
-  exports.default = a;
+  exports['default'] = a;
 
   // Any replacement for the `export default` above needs to happen in the same
   // location. It cannot be done, say, at the end of the file. Otherwise the new

--- a/test/es6-module-transpiler-tests/output/export-default/importer.js
+++ b/test/es6-module-transpiler-tests/output/export-default/importer.js
@@ -7,11 +7,11 @@
 
   /* jshint esnext:true */
 
-  assert.equal(value.default, 42);
+  assert.equal(value['default'], 42);
 
   value.change();
   assert.equal(
-    value.default,
+    value['default'],
     42,
     'default export should not be bound'
   );

--- a/test/es6-module-transpiler-tests/output/export-mixins/exporter.js
+++ b/test/es6-module-transpiler-tests/output/export-mixins/exporter.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	exports.default = 1;
+	exports['default'] = 1;
 	var bar = 2;
 
 	exports.bar = bar;

--- a/test/es6-module-transpiler-tests/output/export-mixins/importer.js
+++ b/test/es6-module-transpiler-tests/output/export-mixins/importer.js
@@ -4,7 +4,7 @@
 
 	var exporter = require('./exporter');
 
-	assert.equal(exporter.default, 1);
+	assert.equal(exporter['default'], 1);
 	assert.equal(exporter.bar, 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/import-as/exporter.js
+++ b/test/es6-module-transpiler-tests/output/import-as/exporter.js
@@ -6,7 +6,7 @@
 
 	var a = 'a';
 	var b = 'b';
-	exports.default = 'DEF';
+	exports['default'] = 'DEF';
 
 	exports.a = a;
 	exports.b = b;

--- a/test/es6-module-transpiler-tests/output/namespaces/exporter.js
+++ b/test/es6-module-transpiler-tests/output/namespaces/exporter.js
@@ -6,7 +6,7 @@
 
 	var a = 'a';
 	var b = 'b';
-	exports.default = 'DEF';
+	exports['default'] = 'DEF';
 
 	exports.a = a;
 	exports.b = b;

--- a/test/es6-module-transpiler-tests/output/re-export-default-import/first.js
+++ b/test/es6-module-transpiler-tests/output/re-export-default-import/first.js
@@ -7,6 +7,6 @@
   function hi() {
     return 'hi';
   }
-  exports.default = hi;
+  exports['default'] = hi;
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/output/re-export-default-import/second.js
+++ b/test/es6-module-transpiler-tests/output/re-export-default-import/second.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	Object.defineProperty(exports, 'hi', { get: function () { return hi.default; }});
+	Object.defineProperty(exports, 'hi', { get: function () { return hi['default']; }});
 
 	var hi = require('./first');
 

--- a/test/strictMode/output/amd/earlyExport.js
+++ b/test/strictMode/output/amd/earlyExport.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	exports.default = foo;
+	exports['default'] = foo;
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/strictMode/output/amd/emptyImportWithDefaultExport.js
+++ b/test/strictMode/output/amd/emptyImportWithDefaultExport.js
@@ -2,6 +2,6 @@ define(['exports', 'foo', 'polyfills'], function (exports, foo) {
 
 	'use strict';
 
-	exports.default = 'baz';
+	exports['default'] = 'baz';
 
 });

--- a/test/strictMode/output/amd/exportAnonFunction.js
+++ b/test/strictMode/output/amd/exportAnonFunction.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	exports.default = function () {
+	exports['default'] = function () {
 		console.log( 'I am anonymous' );
 	}
 

--- a/test/strictMode/output/amd/exportDefault.js
+++ b/test/strictMode/output/amd/exportDefault.js
@@ -2,6 +2,6 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	exports.default = 'foo';
+	exports['default'] = 'foo';
 
 });

--- a/test/strictMode/output/amd/exportFunction.js
+++ b/test/strictMode/output/amd/exportFunction.js
@@ -5,6 +5,6 @@ define(['exports'], function (exports) {
 	function foo ( str ) {
 		return str.toUpperCase();
 	}
-	exports.default = foo;
+	exports['default'] = foo;
 
 });

--- a/test/strictMode/output/amd/importDefault.js
+++ b/test/strictMode/output/amd/importDefault.js
@@ -2,6 +2,6 @@ define(['foo'], function (foo) {
 
 	'use strict';
 
-	console.log( foo.default );
+	console.log( foo['default'] );
 
 });

--- a/test/strictMode/output/amd/multipleImports.js
+++ b/test/strictMode/output/amd/multipleImports.js
@@ -2,7 +2,7 @@ define(['exports', 'foo', 'bar', 'baz'], function (exports, foo, bar, baz) {
 
 	'use strict';
 
-	var qux = foo.default( bar.default( baz.default ) );
-	exports.default = qux;
+	var qux = foo['default']( bar['default']( baz['default'] ) );
+	exports['default'] = qux;
 
 });

--- a/test/strictMode/output/cjs/earlyExport.js
+++ b/test/strictMode/output/cjs/earlyExport.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	exports.default = foo;
+	exports['default'] = foo;
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/strictMode/output/cjs/emptyImportWithDefaultExport.js
+++ b/test/strictMode/output/cjs/emptyImportWithDefaultExport.js
@@ -5,6 +5,6 @@
 	var foo = require('foo');
 	require('polyfills');
 
-	exports.default = 'baz';
+	exports['default'] = 'baz';
 
 }).call(global);

--- a/test/strictMode/output/cjs/exportAnonFunction.js
+++ b/test/strictMode/output/cjs/exportAnonFunction.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	exports.default = function () {
+	exports['default'] = function () {
 		console.log( 'I am anonymous' );
 	}
 

--- a/test/strictMode/output/cjs/exportDefault.js
+++ b/test/strictMode/output/cjs/exportDefault.js
@@ -2,6 +2,6 @@
 
 	'use strict';
 
-	exports.default = 'foo';
+	exports['default'] = 'foo';
 
 }).call(global);

--- a/test/strictMode/output/cjs/exportFunction.js
+++ b/test/strictMode/output/cjs/exportFunction.js
@@ -5,6 +5,6 @@
 	function foo ( str ) {
 		return str.toUpperCase();
 	}
-	exports.default = foo;
+	exports['default'] = foo;
 
 }).call(global);

--- a/test/strictMode/output/cjs/importDefault.js
+++ b/test/strictMode/output/cjs/importDefault.js
@@ -4,6 +4,6 @@
 
 	var foo = require('foo');
 
-	console.log( foo.default );
+	console.log( foo['default'] );
 
 }).call(global);

--- a/test/strictMode/output/cjs/multipleImports.js
+++ b/test/strictMode/output/cjs/multipleImports.js
@@ -6,7 +6,7 @@
 	var bar = require('bar');
 	var baz = require('baz');
 
-	var qux = foo.default( bar.default( baz.default ) );
-	exports.default = qux;
+	var qux = foo['default']( bar['default']( baz['default'] ) );
+	exports['default'] = qux;
 
 }).call(global);

--- a/test/strictMode/output/umd/earlyExport.js
+++ b/test/strictMode/output/umd/earlyExport.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	exports.default = foo;
+	exports['default'] = foo;
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/strictMode/output/umd/emptyImportWithDefaultExport.js
+++ b/test/strictMode/output/umd/emptyImportWithDefaultExport.js
@@ -18,6 +18,6 @@
 
 	'use strict';
 
-	exports.default = 'baz';
+	exports['default'] = 'baz';
 
 }));

--- a/test/strictMode/output/umd/exportAnonFunction.js
+++ b/test/strictMode/output/umd/exportAnonFunction.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	exports.default = function () {
+	exports['default'] = function () {
 		console.log( 'I am anonymous' );
 	}
 

--- a/test/strictMode/output/umd/exportDefault.js
+++ b/test/strictMode/output/umd/exportDefault.js
@@ -18,6 +18,6 @@
 
 	'use strict';
 
-	exports.default = 'foo';
+	exports['default'] = 'foo';
 
 }));

--- a/test/strictMode/output/umd/exportFunction.js
+++ b/test/strictMode/output/umd/exportFunction.js
@@ -21,6 +21,6 @@
 	function foo ( str ) {
 		return str.toUpperCase();
 	}
-	exports.default = foo;
+	exports['default'] = foo;
 
 }));

--- a/test/strictMode/output/umd/importDefault.js
+++ b/test/strictMode/output/umd/importDefault.js
@@ -18,6 +18,6 @@
 
 	'use strict';
 
-	console.log( foo.default );
+	console.log( foo['default'] );
 
 }));

--- a/test/strictMode/output/umd/multipleImports.js
+++ b/test/strictMode/output/umd/multipleImports.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	var qux = foo.default( bar.default( baz.default ) );
-	exports.default = qux;
+	var qux = foo['default']( bar['default']( baz['default'] ) );
+	exports['default'] = qux;
 
 }));


### PR DESCRIPTION
I was testing something in ie8 (_ugh_) and it seems to not like `exports.default` anywhere. Apparently this is a syntactic restriction that was lifted with es5.

This swaps all of the references to `.default` with the es3-friendly array notation `['default']`.
