### PR TITLE
Ensure objects used as maps properly check for key existence.

### DIFF
--- a/src/bundler/combine/gatherImports.js
+++ b/src/bundler/combine/gatherImports.js
@@ -4,7 +4,7 @@ export default function gatherImports ( imports, externalModuleLookup, importedB
 	imports.forEach( x => {
 		var external;
 
-		if ( !!externalModuleLookup[ x.path ] ) {
+		if ( externalModuleLookup.hasOwnProperty( x.path ) ) {
 			external = true;
 		}
 
@@ -22,7 +22,7 @@ export default function gatherImports ( imports, externalModuleLookup, importedB
 
 				// If this is a chained import, get the origin
 				hash = moduleId + '@' + specifierName;
-				while ( chains[ hash ] ) {
+				while ( chains.hasOwnProperty( hash ) ) {
 					hash = chains[ hash ];
 					isChained = true;
 				}

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -55,7 +55,7 @@ export default function getBundle ( options ) {
 
 		modulePath = path.resolve( base, moduleId + '.js' );
 
-		if ( !promiseById[ moduleId ] ) {
+		if ( !promiseById.hasOwnProperty( moduleId ) ) {
 			promiseById[ moduleId ] = sander.readFile( modulePath ).catch( function ( err ) {
 				if ( err.code === 'ENOENT' ) {
 					modulePath = modulePath.replace( /\.js$/, '/index.js' );
@@ -104,7 +104,7 @@ export default function getBundle ( options ) {
 					}
 
 					// Most likely an external module
-					if ( !externalModuleLookup[ moduleId ] ) {
+					if ( !externalModuleLookup.hasOwnProperty( moduleId ) ) {
 						externalModule = {
 							id: moduleId
 						};

--- a/src/bundler/utils/getUniqueNames.js
+++ b/src/bundler/utils/getUniqueNames.js
@@ -19,7 +19,7 @@ export default function getUniqueNames ( modules, userNames ) {
 			var id = resolve( x.path, mod.file );
 			x.id = id;
 
-			if ( x.default && !names[ id ] && !used[ x.name ] ) {
+			if ( x.default && !names.hasOwnProperty( id ) && !used.hasOwnProperty( x.name ) ) {
 				names[ id ] = x.name;
 				used[ x.name ] = true;
 			}
@@ -32,7 +32,7 @@ export default function getUniqueNames ( modules, userNames ) {
 		var parts, i, name;
 
 		// is this already named?
-		if ( names[ mod.id ] ) {
+		if ( names.hasOwnProperty( mod.id ) ) {
 			return;
 		}
 
@@ -42,12 +42,12 @@ export default function getUniqueNames ( modules, userNames ) {
 		while ( i-- ) {
 			name = sanitize( parts.slice( i ).join( '_' ) );
 
-			if ( !used[ name ] ) {
+			if ( !used.hasOwnProperty( name ) ) {
 				break;
 			}
 		}
 
-		while ( used[ name ] ) {
+		while ( used.hasOwnProperty( name ) ) {
 			name = '_' + name;
 		}
 

--- a/src/bundler/utils/resolveChains.js
+++ b/src/bundler/utils/resolveChains.js
@@ -14,8 +14,8 @@ export default function resolveChains ( modules, moduleLookup ) {
 				if ( s.batch ) {
 					// if this is an internal module, we need to tell that module that
 					// it needs to export an object full of getters
-					if ( namespaceExporter = moduleLookup[ moduleId ] ) {
-						namespaceExporter._exportsNamespace = true;
+					if ( moduleLookup.hasOwnProperty( moduleId ) ) {
+						moduleLookup[ moduleId ]._exportsNamespace = true;
 					}
 
 					return; // TODO can batch imports be chained?
@@ -29,10 +29,8 @@ export default function resolveChains ( modules, moduleLookup ) {
 			if ( !x.specifiers ) return;
 
 			x.specifiers.forEach( s => {
-				var o = origin[ s.name ];
-
-				if ( o ) {
-					chains[ mod.id + '@' + s.name ] = o;
+				if ( origin.hasOwnProperty( s.name ) ) {
+					chains[ mod.id + '@' + s.name ] = origin[ s.name ];
 				}
 			});
 		});

--- a/src/bundler/utils/sortModules.js
+++ b/src/bundler/utils/sortModules.js
@@ -7,7 +7,7 @@ export default function sortModules ( entry, moduleLookup ) {
 	function visit ( mod ) {
 		// ignore external modules, and modules we've
 		// already included
-		if ( !mod || seen[ mod.id ] ) {
+		if ( !mod || seen.hasOwnProperty( mod.id ) ) {
 			return;
 		}
 

--- a/src/standalone/builders/defaultsMode/cjs.js
+++ b/src/standalone/builders/defaultsMode/cjs.js
@@ -24,11 +24,13 @@ export default function cjs ( mod, body, options ) {
 	if ( exportDeclaration ) {
 		switch ( exportDeclaration.type ) {
 			case 'namedFunction':
+			case 'namedClass':
 			body.remove( exportDeclaration.start, exportDeclaration.valueStart );
 			body.replace( exportDeclaration.end, exportDeclaration.end, `\nmodule.exports = ${exportDeclaration.node.declaration.id.name};` );
 			break;
 
 			case 'anonFunction':
+			case 'anonClass':
 			case 'expression':
 			body.replace( exportDeclaration.start, exportDeclaration.valueStart, 'module.exports = ' );
 			break;

--- a/src/standalone/builders/defaultsMode/utils/transformExportDeclaration.js
+++ b/src/standalone/builders/defaultsMode/utils/transformExportDeclaration.js
@@ -4,11 +4,13 @@ export default function transformExportDeclaration ( declaration, body ) {
 	if ( declaration ) {
 		switch ( declaration.type ) {
 			case 'namedFunction':
+			case 'namedClass':
 				body.remove( declaration.start, declaration.valueStart );
 				exportedValue = declaration.name;
 				break;
 
 			case 'anonFunction':
+			case 'anonClass':
 				if ( declaration.isFinal ) {
 					body.replace( declaration.start, declaration.valueStart, 'return ' );
 				} else {

--- a/src/standalone/builders/strictMode/utils/transformBody.js
+++ b/src/standalone/builders/strictMode/utils/transformBody.js
@@ -95,6 +95,7 @@ export default function transformBody ( mod, body, options ) {
 				return;
 
 			case 'namedFunction':
+			case 'namedClass':
 				if ( x.default ) {
 					// export default function answer () { return 42; }
 					defaultValue = body.slice( x.valueStart, x.end );
@@ -107,6 +108,7 @@ export default function transformBody ( mod, body, options ) {
 				return;
 
 			case 'anonFunction':
+			case 'anonClass':
 				// export default function () {}
 				body.replace( x.start, x.valueStart, 'exports[\'default\'] = ' );
 				return;

--- a/src/standalone/getModuleNameHelper.js
+++ b/src/standalone/getModuleNameHelper.js
@@ -13,15 +13,15 @@ export default function moduleNameHelper ( userFn, varNames ) {
 		moduleId = x.path;
 
 		// use existing value
-		if ( name = nameById[ moduleId ] ) {
-			return name;
+		if ( nameById.hasOwnProperty( moduleId ) ) {
+			return nameById[ moduleId ];
 		}
 
 		// if user supplied a function, defer to it
 		if ( userFn && ( name = userFn( moduleId ) ) ) {
 			name = sanitize( name );
 
-			if ( usedNames[ name ] ) {
+			if ( usedNames.hasOwnProperty( name ) ) {
 				// TODO write a test for this
 				throw new Error( 'Naming collision: module ' + moduleId + ' cannot be called ' + name );
 			}
@@ -43,7 +43,7 @@ export default function moduleNameHelper ( userFn, varNames ) {
 				while ( i-- ) {
 					candidate = prefix + sanitize( parts.slice( i ).join( '__' ) );
 
-					if ( !usedNames[ candidate ] ) {
+					if ( !usedNames.hasOwnProperty( candidate ) ) {
 						name = candidate;
 						break;
 					}

--- a/src/utils/annotateAst.js
+++ b/src/utils/annotateAst.js
@@ -96,7 +96,12 @@ function createsBlockScope ( node ) {
 }
 
 function declaresVar ( node ) {
-	return node.type === 'VariableDeclarator'; // TODO const, class? (function taken care of already)
+	// TODO const? (function taken care of already)
+	return (
+		node.type === 'VariableDeclarator' ||
+		node.type === 'ClassExpression' ||
+		node.type === 'ClassDeclaration'
+	);
 }
 
 function declaresLet ( node ) {

--- a/src/utils/disallowIllegalReassignment.js
+++ b/src/utils/disallowIllegalReassignment.js
@@ -21,7 +21,7 @@ export default function disallowIllegalReassignment ( node, names, scope ) {
 	}
 
 	name = assignee.name;
-	replacement = names[ name ];
+	replacement = names.hasOwnProperty( name ) && names[ name ];
 
 	if ( !!replacement && !scope.contains( name ) ) {
 		throw new Error( message + '`' + name + '`' );

--- a/src/utils/findImportsAndExports.js
+++ b/src/utils/findImportsAndExports.js
@@ -132,7 +132,31 @@ function processExport ( node, source ) {
 			}
 		}
 
-		// Case 5: `export default 1 + 2`
+		// Case 5: `export class Foo {...}`
+		else if ( d.type === 'ClassDeclaration' ) {
+			result.declaration = true; // TODO remove in favour of result.type
+			result.type = 'namedClass';
+			result.default = !!node.default;
+			result.name = d.id.name;
+		}
+
+		else if ( d.type === 'ClassExpression' ) {
+			result.declaration = true; // TODO remove in favour of result.type
+			result.default = true;
+
+			// Case 6: `export default class Foo {...}`
+			if ( d.id ) {
+				result.type = 'namedClass';
+				result.name = d.id.name;
+			}
+
+			// Case 7: `export default class {...}`
+			else {
+				result.type = 'anonClass';
+			}
+		}
+
+		// Case 8: `export default 1 + 2`
 		else {
 			result.type = 'expression';
 			result.default = true;
@@ -140,7 +164,7 @@ function processExport ( node, source ) {
 		}
 	}
 
-	// Case 6: `export { foo, bar };`
+	// Case 9: `export { foo, bar };`
 	else {
 		result.type = 'named';
 		result.specifiers = node.specifiers.map( s => ({ name: s.id.name }) ); // TODO as?

--- a/src/utils/rewriteIdentifiers.js
+++ b/src/utils/rewriteIdentifiers.js
@@ -3,7 +3,7 @@ export default function rewriteIdentifiers ( body, node, toRewrite, scope ) {
 
 	if ( node.type === 'Identifier' ) {
 		name = node.name;
-		replacement = toRewrite[ name ];
+		replacement = toRewrite.hasOwnProperty( name ) && toRewrite[ name ];
 
 		if ( replacement && !scope.contains( name ) ) {
 			// rewrite

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -116,7 +116,8 @@ module.exports = function () {
 			{ dir: '6', description: 'gives legal names to nested imports' },
 			{ dir: '7', description: 'modules can be skipped' },
 			{ dir: '8', description: 'external module names are guessed (affects UMD only)' },
-			{ dir: '9', description: 'external module names can be specified (affects UMD only)' }
+			{ dir: '9', description: 'external module names can be specified (affects UMD only)' },
+			{ dir: '10', description: 'does not affect ES6 classes' },
 		];
 
 		profiles.forEach( function ( profile ) {

--- a/test/bundle/input/10/main.js
+++ b/test/bundle/input/10/main.js
@@ -1,0 +1,9 @@
+export default class Foo {
+	constructor( str ) {
+		this.str = str;
+	}
+
+	toString() {
+		return this.str;
+	}
+}

--- a/test/bundle/output/amd/10.js
+++ b/test/bundle/output/amd/10.js
@@ -1,0 +1,18 @@
+define(['exports'], function (exports) {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	exports['default'] = main__default;
+
+});

--- a/test/bundle/output/amdDefaults/10.js
+++ b/test/bundle/output/amdDefaults/10.js
@@ -1,0 +1,18 @@
+define(function () {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	return main__default;
+
+});

--- a/test/bundle/output/cjs/10.js
+++ b/test/bundle/output/cjs/10.js
@@ -1,0 +1,18 @@
+(function () {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	exports['default'] = main__default;
+
+}).call(global);

--- a/test/bundle/output/cjsDefaults/10.js
+++ b/test/bundle/output/cjsDefaults/10.js
@@ -1,0 +1,18 @@
+(function () {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	module.exports = main__default;
+
+}).call(global);

--- a/test/bundle/output/umd/10.js
+++ b/test/bundle/output/umd/10.js
@@ -1,0 +1,34 @@
+(function (global, factory) {
+
+	'use strict';
+
+	if (typeof define === 'function' && define.amd) {
+		// export as AMD
+		define(['exports'], factory);
+	} else if (typeof module !== 'undefined' && module.exports && typeof require === 'function') {
+		// node/browserify
+		factory(exports);
+	} else {
+		// browser global
+		global.myModule = {};
+		factory(global.myModule);
+	}
+
+}(typeof window !== 'undefined' ? window : this, function (exports) {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	exports['default'] = main__default;
+
+}));

--- a/test/bundle/output/umdDefaults/10.js
+++ b/test/bundle/output/umdDefaults/10.js
@@ -1,0 +1,33 @@
+(function (global, factory) {
+
+	'use strict';
+
+	if (typeof define === 'function' && define.amd) {
+		// export as AMD
+		define([], factory);
+	} else if (typeof module !== 'undefined' && module.exports && typeof require === 'function') {
+		// node/browserify
+		module.exports = factory();
+	} else {
+		// browser global
+		global.myModule = factory();
+	}
+
+}(typeof window !== 'undefined' ? window : this, function () {
+
+	'use strict';
+
+	class main__Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+	var main__default = main__Foo;
+
+	return main__default;
+
+}));


### PR DESCRIPTION
Objects can be dangerous to use as maps for arbitrary strings as a string might be one of the methods on Object.prototype. This is illustrated by https://github.com/Rich-Harris/esperanto/issues/21.

This mitigates the issue by calling hasOwnProperty to check existence before using a value from an Object used as a Map.

Also includes a test which fails before the diff.

Fixes support for classes to better illustrate test case.
