### PR TITLE
[RFC] Only alter Identifiers to avoid conflict.

### DIFF
--- a/src/bundler/builders/defaultsMode/amd.js
+++ b/src/bundler/builders/defaultsMode/amd.js
@@ -13,13 +13,17 @@ export default function amd ( bundle, body, options ) {
 	indentStr = body.getIndentString();
 
 	if ( x = entry.exports[0] ) {
-		exportStatement = indentStr + 'return ' + bundle.uniqueNames[ bundle.entry ] + '__default;';
+		var name = bundle.uniqueNames[ bundle.entry ];
+		if ( bundle.conflicts.hasOwnProperty( name ) ) {
+			name += '__default';
+		}
+		exportStatement = indentStr + 'return ' + name + ';';
 		body.append( '\n\n' + exportStatement );
 	}
 
 	intro = introTemplate({
 		amdDeps: bundle.externalModules.length ? '[' + bundle.externalModules.map( quoteId ).join( ', ' ) + '], ' : '',
-		names: bundle.externalModules.map( m => bundle.uniqueNames[ m.id ] ).join( ', ' )
+		names: bundle.externalModules.map( m => bundle.uniqueNames[ m.id ] + '__default' ).join( ', ' )
 	}).replace( /\t/g, indentStr );
 
 	body.prepend( intro ).trim().append( '\n\n});' );

--- a/src/bundler/builders/defaultsMode/cjs.js
+++ b/src/bundler/builders/defaultsMode/cjs.js
@@ -20,7 +20,11 @@ export default function cjs ( bundle, body, options ) {
 	}
 
 	if ( x = entry.exports[0] ) {
-		exportStatement = indentStr + 'module.exports = ' + bundle.uniqueNames[ bundle.entry ] + '__default;';
+		var name = bundle.uniqueNames[ bundle.entry ];
+		if ( bundle.conflicts.hasOwnProperty( name ) ) {
+			name += '__default';
+		}
+		exportStatement = indentStr + 'module.exports = ' + name + ';';
 		body.append( '\n\n' + exportStatement );
 	}
 

--- a/src/bundler/builders/defaultsMode/umd.js
+++ b/src/bundler/builders/defaultsMode/umd.js
@@ -20,7 +20,11 @@ export default function umd ( bundle, body, options ) {
 	}
 
 	if ( x = entry.exports[0] ) {
-		exportStatement = indentStr + 'return ' + bundle.uniqueNames[ bundle.entry ] + '__default;';
+		var name = bundle.uniqueNames[ bundle.entry ];
+		if ( bundle.conflicts.hasOwnProperty( name ) ) {
+			name += '__default';
+		}
+		exportStatement = indentStr + 'return ' + name + ';';
 		body.append( '\n\n' + exportStatement );
 	}
 

--- a/src/bundler/builders/strictMode/cjs.js
+++ b/src/bundler/builders/strictMode/cjs.js
@@ -14,7 +14,7 @@ export default function cjs ( bundle, body, options ) {
 		var name = bundle.uniqueNames[ x.id ];
 
 		return indentStr + `var ${name} = require('${x.id}');\n` +
-		       indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
+					 indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 	}).join( '\n' );
 
 	if ( importBlock ) {

--- a/src/bundler/builders/strictMode/utils/getExportBlock.js
+++ b/src/bundler/builders/strictMode/utils/getExportBlock.js
@@ -9,7 +9,11 @@ export default function getExportBlock ( bundle, entry, indentStr ) {
 
 	// create an export block
 	if ( entry.defaultExport ) {
-		exportBlock = indentStr + 'exports[\'default\'] = ' + name + '__default;';
+		var defaultName = name;
+		if ( bundle.conflicts.hasOwnProperty( name ) ) {
+			defaultName += '__default';
+		}
+		exportBlock = indentStr + 'exports[\'default\'] = ' + defaultName + ';';
 	}
 
 	entry.exports.forEach( x => {
@@ -18,12 +22,18 @@ export default function getExportBlock ( bundle, entry, indentStr ) {
 		}
 
 		if ( x.declaration ) {
-			statements.push( indentStr + `__export('${x.name}', function () { return ${name}__${x.name}; });`  );
+			var declName = bundle.conflicts.hasOwnProperty( x.name ) ?
+				name + '__' + x.name :
+				x.name;
+			statements.push( indentStr + `__export('${x.name}', function () { return ${declName}; });`  );
 		}
 
 		else {
 			x.specifiers.forEach( s => {
-				statements.push( indentStr + `__export('${s.name}', function () { return ${name}__${s.name}; });`  );
+				var declName = bundle.conflicts.hasOwnProperty( s.name ) ?
+					name + '__' + s.name :
+					s.name;
+				statements.push( indentStr + `__export('${s.name}', function () { return ${declName}; });`  );
 			});
 		}
 	});

--- a/src/bundler/combine/gatherExports.js
+++ b/src/bundler/combine/gatherExports.js
@@ -1,11 +1,20 @@
-export default function gatherExports ( exports, toRewrite, prefix ) {
+export default function gatherExports ( exports, toRewrite, prefix, conflicts ) {
 	exports.forEach( x => {
-		if ( !x.specifiers ) {
-			return;
+		if ( x.declaration ) {
+			var name = x.name;
+			if ( !toRewrite.hasOwnProperty( name ) ) {
+				toRewrite[ name ] = conflicts.hasOwnProperty( name ) ?
+					prefix + '__' + name :
+					name;
+			}
+		} else if ( x.specifiers ) {
+			x.specifiers.forEach( s => {
+				if ( !toRewrite.hasOwnProperty( s.name ) ) {
+					toRewrite[ s.name ] = conflicts.hasOwnProperty( s.name ) ?
+						prefix + '__' + s.name :
+						s.name;
+				}
+			});
 		}
-
-		x.specifiers.forEach( s => {
-			toRewrite[ s.name ] = prefix + '__' + s.name;
-		});
 	});
 }

--- a/src/bundler/combine/gatherImports.js
+++ b/src/bundler/combine/gatherImports.js
@@ -1,4 +1,4 @@
-export default function gatherImports ( imports, externalModuleLookup, importedBindings, toRewrite, chains, uniqueNames ) {
+export default function gatherImports ( imports, externalModuleLookup, importedBindings, toRewrite, chains, uniqueNames, conflicts ) {
 	var replacements = {};
 
 	imports.forEach( x => {
@@ -35,8 +35,14 @@ export default function gatherImports ( imports, externalModuleLookup, importedB
 
 				moduleName = uniqueNames[ moduleId ];
 
-				if ( !external || specifierName === 'default' ) {
-					replacement = moduleName + '__' + specifierName;
+				if ( specifierName === 'default' ) {
+					replacement = external || conflicts.hasOwnProperty( moduleName ) ?
+						moduleName + '__default' :
+						moduleName;
+				} else if ( !external ) {
+					replacement = conflicts.hasOwnProperty( specifierName ) ?
+						moduleName + '__' + specifierName :
+						specifierName;
 				} else {
 					replacement = moduleName + '.' + specifierName;
 				}

--- a/src/bundler/combine/importsByModule.js
+++ b/src/bundler/combine/importsByModule.js
@@ -1,0 +1,15 @@
+export default function importsByModule ( bundle ) {
+	var imports = {};
+
+	bundle.modules.forEach( mod => {
+		mod.imports.forEach(i => {
+			i.specifiers.forEach(s => {
+				if ( !s.default ) {
+					(imports[ i.id ] || (imports[ i.id ] = {}))[ s.name ] = true;
+				}
+			});
+		});
+	});
+
+	return imports;
+}

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -1,5 +1,7 @@
 import path from 'path';
 import MagicString from 'magic-string';
+import topLevelScopeConflicts from './topLevelScopeConflicts';
+import importsByModule from './importsByModule';
 import transformBody from './transformBody';
 import annotateAst from '../../utils/annotateAst';
 
@@ -9,11 +11,20 @@ export default function combine ( bundle ) {
 	});
 
 	bundle.modules.forEach( mod => {
+		annotateAst( mod.ast );
+	});
+
+	var conflicts = topLevelScopeConflicts( bundle );
+	bundle.conflicts = conflicts;
+
+	var imports = importsByModule( bundle );
+	bundle.importsByModule = imports;
+
+	bundle.modules.forEach( mod => {
 		var modBody = mod.body.clone(),
 			prefix = bundle.uniqueNames[ mod.id ];
 
-		annotateAst( mod.ast );
-		transformBody( bundle, mod, modBody, prefix );
+		transformBody( bundle, mod, modBody, prefix, conflicts );
 
 		body.addSource({
 			filename: path.resolve( bundle.base, mod.file ),

--- a/src/bundler/combine/topLevelScopeConflicts.js
+++ b/src/bundler/combine/topLevelScopeConflicts.js
@@ -1,0 +1,35 @@
+import getUnscopedNames from '../utils/getUnscopedNames';
+
+export default function topLevelScopeConflicts ( bundle ) {
+	var conflicts = {};
+	var inScope = {};
+
+	bundle.modules.forEach( mod => {
+		var inModule = {};
+
+		// bundle name is in top scope
+		inModule[ bundle.uniqueNames[ mod.id ] ] = true;
+
+		// all top defined identifiers are in top scope
+		mod.ast._scope.names.forEach( name => {
+			inModule[ name ] = true;
+		});
+
+		// all unattributed identifiers could collide with top scope
+		var unscoped = getUnscopedNames( mod );
+		Object.keys( getUnscopedNames( mod ) ).forEach( name => {
+			inModule[ name ] = true;
+		});
+
+		// merge this module's top scope with bundle top scope
+		Object.keys( inModule ).forEach( name => {
+			if ( inScope.hasOwnProperty( name ) ) {
+				conflicts[ name ] = true;
+			} else {
+				inScope[ name ] = true;
+			}
+		});
+	});
+
+	return conflicts;
+}

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -41,7 +41,7 @@ export default function getBundle ( options ) {
 				externalModuleLookup: externalModuleLookup,
 				skip: skip,
 				names: names,
-				uniqueNames: getUniqueNames( modules, options.names ),
+				uniqueNames: getUniqueNames( modules, names ),
 				chains: resolveChains( modules, moduleLookup )
 			};
 

--- a/src/bundler/utils/getUnscopedNames.js
+++ b/src/bundler/utils/getUnscopedNames.js
@@ -1,0 +1,49 @@
+import estraverse from 'estraverse';
+
+export default function getUnscopedNames ( mod ) {
+	var unscoped = {};
+
+	var importedNames;
+	function imported ( name ) {
+		if (!importedNames) {
+			importedNames = {};
+			mod.imports.forEach(i => {
+				!i.passthrough && i.specifiers.forEach(s => {
+					importedNames[ s.batch ? s.name : s.as ] = true;
+				});
+			});
+		}
+		return importedNames.hasOwnProperty( name );
+	}
+
+	var scope;
+
+	estraverse.traverse( mod.ast, {
+		enter: function ( node, parent ) {
+			// we're only interested in references, not property names etc
+			if ( node._skip ) return this.skip();
+
+			if ( node._scope ) {
+				scope = node._scope;
+			}
+
+			if ( node.type === 'Identifier' &&
+					 !scope.contains( node.name ) &&
+					 !imported( node.name ) ) {
+				unscoped[ node.name ] = true;
+			}
+		},
+
+		leave: function ( node ) {
+			if ( node.type === 'Program' ) {
+				return;
+			}
+
+			if ( node._scope ) {
+				scope = scope.parent;
+			}
+		}
+	});
+
+	return unscoped;
+}

--- a/src/utils/rewriteIdentifiers.js
+++ b/src/utils/rewriteIdentifiers.js
@@ -1,11 +1,13 @@
-export default function rewriteIdentifiers ( body, node, toRewrite, scope ) {
+export default function rewriteIdentifiers ( body, node, toRewrite, scope, unscoped ) {
 	var name, replacement;
 
 	if ( node.type === 'Identifier' ) {
 		name = node.name;
 		replacement = toRewrite.hasOwnProperty( name ) && toRewrite[ name ];
 
-		if ( replacement && !scope.contains( name ) ) {
+		if ( replacement &&
+				 !scope.contains( name ) &&
+				 !(unscoped && unscoped.hasOwnProperty( name )) ) {
 			// rewrite
 			body.replace( node.start, node.end, replacement );
 		}

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -44,6 +44,7 @@ module.exports = function () {
 				{ entry: 'importer', dir: 'import-as' },
 				{ entry: 'third', dir: 'import-chain' },
 				{ entry: 'index', dir: 'import-not-at-top-level-fails', expectedError: "'import' and 'export' may only appear at the top level" },
+				{ entry: 'importer', dir: 'import-not-exported' },
 				{ entry: 'mod', dir: 'module-level-declarations' },
 				{ entry: 'importer', dir: 'named-function-expression' },
 				{ entry: 'importer', dir: 'namespace-reassign-import-fails', expectedError: 'Cannot reassign imported binding of namespace `exp`' },

--- a/test/bundle/output/amd/1.js
+++ b/test/bundle/output/amd/1.js
@@ -2,9 +2,9 @@ define(function () {
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 });

--- a/test/bundle/output/amd/10.js
+++ b/test/bundle/output/amd/10.js
@@ -2,7 +2,7 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -11,8 +11,8 @@ define(['exports'], function (exports) {
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 });

--- a/test/bundle/output/amd/2.js
+++ b/test/bundle/output/amd/2.js
@@ -2,9 +2,9 @@ define(function () {
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 });

--- a/test/bundle/output/amd/3.js
+++ b/test/bundle/output/amd/3.js
@@ -4,9 +4,9 @@ define(['external'], function (external) {
 
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 });

--- a/test/bundle/output/amd/4.js
+++ b/test/bundle/output/amd/4.js
@@ -2,10 +2,10 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 });

--- a/test/bundle/output/amd/5.js
+++ b/test/bundle/output/amd/5.js
@@ -2,20 +2,20 @@ define(['exports'], function (exports) {
 
 	'use strict';
 
-	var numbers__one = 1;
-	var numbers__two = 2;
-	var numbers__three = 3;
+	var one = 1;
+	var two = 2;
+	var three = 3;
 
-	var main__four = numbers__one + 3;
-	var main__five = numbers__two + 3;
-	var main__six = numbers__three + 3;
+	var four = one + 3;
+	var five = two + 3;
+	var six = three + 3;
 
 
 
 	(function (__export) {
-		__export('four', function () { return main__four; });
-	__export('five', function () { return main__five; });
-	__export('six', function () { return main__six; });
+		__export('four', function () { return four; });
+	__export('five', function () { return five; });
+	__export('six', function () { return six; });
 	}(function (prop, get) {
 		Object.defineProperty(exports, prop, {
 			enumerable: true,

--- a/test/bundle/output/amd/6.js
+++ b/test/bundle/output/amd/6.js
@@ -4,8 +4,8 @@ define(['utils/external'], function (external) {
 
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 });

--- a/test/bundle/output/amd/7.js
+++ b/test/bundle/output/amd/7.js
@@ -2,14 +2,14 @@ define(function () {
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 });

--- a/test/bundle/output/amdDefaults/1.js
+++ b/test/bundle/output/amdDefaults/1.js
@@ -2,9 +2,9 @@ define(function () {
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 });

--- a/test/bundle/output/amdDefaults/10.js
+++ b/test/bundle/output/amdDefaults/10.js
@@ -2,7 +2,7 @@ define(function () {
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -11,8 +11,8 @@ define(function () {
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	return main__default;
+	return main;
 
 });

--- a/test/bundle/output/amdDefaults/2.js
+++ b/test/bundle/output/amdDefaults/2.js
@@ -2,9 +2,9 @@ define(function () {
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 });

--- a/test/bundle/output/amdDefaults/3.js
+++ b/test/bundle/output/amdDefaults/3.js
@@ -1,10 +1,10 @@
-define(['external'], function (external) {
+define(['external'], function (external__default) {
 
 	'use strict';
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 });

--- a/test/bundle/output/amdDefaults/4.js
+++ b/test/bundle/output/amdDefaults/4.js
@@ -2,10 +2,10 @@ define(function () {
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	return main__default;
+	return main;
 
 });

--- a/test/bundle/output/amdDefaults/6.js
+++ b/test/bundle/output/amdDefaults/6.js
@@ -1,9 +1,9 @@
-define(['utils/external'], function (external) {
+define(['utils/external'], function (external__default) {
 
 	'use strict';
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 });

--- a/test/bundle/output/amdDefaults/7.js
+++ b/test/bundle/output/amdDefaults/7.js
@@ -2,14 +2,14 @@ define(function () {
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 });

--- a/test/bundle/output/amdDefaults/8.js
+++ b/test/bundle/output/amdDefaults/8.js
@@ -1,4 +1,4 @@
-define(['external'], function (ImplicitlyNamed) {
+define(['external'], function (ImplicitlyNamed__default) {
 
 	'use strict';
 

--- a/test/bundle/output/amdDefaults/9.js
+++ b/test/bundle/output/amdDefaults/9.js
@@ -1,4 +1,4 @@
-define(['external'], function (Correct) {
+define(['external'], function (Correct__default) {
 
 	'use strict';
 

--- a/test/bundle/output/cjs/1.js
+++ b/test/bundle/output/cjs/1.js
@@ -2,9 +2,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }).call(global);

--- a/test/bundle/output/cjs/10.js
+++ b/test/bundle/output/cjs/10.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -11,8 +11,8 @@
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 }).call(global);

--- a/test/bundle/output/cjs/2.js
+++ b/test/bundle/output/cjs/2.js
@@ -2,9 +2,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }).call(global);

--- a/test/bundle/output/cjs/3.js
+++ b/test/bundle/output/cjs/3.js
@@ -5,9 +5,9 @@
 	var external = require('external');
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 }).call(global);

--- a/test/bundle/output/cjs/4.js
+++ b/test/bundle/output/cjs/4.js
@@ -2,10 +2,10 @@
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 }).call(global);

--- a/test/bundle/output/cjs/5.js
+++ b/test/bundle/output/cjs/5.js
@@ -2,20 +2,20 @@
 
 	'use strict';
 
-	var numbers__one = 1;
-	var numbers__two = 2;
-	var numbers__three = 3;
+	var one = 1;
+	var two = 2;
+	var three = 3;
 
-	var main__four = numbers__one + 3;
-	var main__five = numbers__two + 3;
-	var main__six = numbers__three + 3;
+	var four = one + 3;
+	var five = two + 3;
+	var six = three + 3;
 
 
 
 	(function (__export) {
-		__export('four', function () { return main__four; });
-	__export('five', function () { return main__five; });
-	__export('six', function () { return main__six; });
+		__export('four', function () { return four; });
+	__export('five', function () { return five; });
+	__export('six', function () { return six; });
 	}(function (prop, get) {
 		Object.defineProperty(exports, prop, {
 			enumerable: true,

--- a/test/bundle/output/cjs/6.js
+++ b/test/bundle/output/cjs/6.js
@@ -5,8 +5,8 @@
 	var external = require('utils/external');
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 }).call(global);

--- a/test/bundle/output/cjs/7.js
+++ b/test/bundle/output/cjs/7.js
@@ -2,14 +2,14 @@
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/1.js
+++ b/test/bundle/output/cjsDefaults/1.js
@@ -2,9 +2,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/10.js
+++ b/test/bundle/output/cjsDefaults/10.js
@@ -2,7 +2,7 @@
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -11,8 +11,8 @@
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	module.exports = main__default;
+	module.exports = main;
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/2.js
+++ b/test/bundle/output/cjsDefaults/2.js
@@ -2,9 +2,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/3.js
+++ b/test/bundle/output/cjsDefaults/3.js
@@ -4,9 +4,9 @@
 
 	var external__default = require('external');
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/4.js
+++ b/test/bundle/output/cjsDefaults/4.js
@@ -2,10 +2,10 @@
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	module.exports = main__default;
+	module.exports = main;
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/6.js
+++ b/test/bundle/output/cjsDefaults/6.js
@@ -4,8 +4,8 @@
 
 	var external__default = require('utils/external');
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 }).call(global);

--- a/test/bundle/output/cjsDefaults/7.js
+++ b/test/bundle/output/cjsDefaults/7.js
@@ -2,14 +2,14 @@
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 }).call(global);

--- a/test/bundle/output/umd/1.js
+++ b/test/bundle/output/umd/1.js
@@ -18,9 +18,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umd/10.js
+++ b/test/bundle/output/umd/10.js
@@ -18,7 +18,7 @@
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -27,8 +27,8 @@
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 }));

--- a/test/bundle/output/umd/2.js
+++ b/test/bundle/output/umd/2.js
@@ -18,9 +18,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umd/3.js
+++ b/test/bundle/output/umd/3.js
@@ -20,9 +20,9 @@
 
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 }));

--- a/test/bundle/output/umd/4.js
+++ b/test/bundle/output/umd/4.js
@@ -18,10 +18,10 @@
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	exports['default'] = main__default;
+	exports['default'] = main;
 
 }));

--- a/test/bundle/output/umd/5.js
+++ b/test/bundle/output/umd/5.js
@@ -18,20 +18,20 @@
 
 	'use strict';
 
-	var numbers__one = 1;
-	var numbers__two = 2;
-	var numbers__three = 3;
+	var one = 1;
+	var two = 2;
+	var three = 3;
 
-	var main__four = numbers__one + 3;
-	var main__five = numbers__two + 3;
-	var main__six = numbers__three + 3;
+	var four = one + 3;
+	var five = two + 3;
+	var six = three + 3;
 
 
 
 	(function (__export) {
-		__export('four', function () { return main__four; });
-	__export('five', function () { return main__five; });
-	__export('six', function () { return main__six; });
+		__export('four', function () { return four; });
+	__export('five', function () { return five; });
+	__export('six', function () { return six; });
 	}(function (prop, get) {
 		Object.defineProperty(exports, prop, {
 			enumerable: true,

--- a/test/bundle/output/umd/6.js
+++ b/test/bundle/output/umd/6.js
@@ -20,8 +20,8 @@
 
 	var external__default = ('default' in external ? external['default'] : external);
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 }));

--- a/test/bundle/output/umd/7.js
+++ b/test/bundle/output/umd/7.js
@@ -18,14 +18,14 @@
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 }));

--- a/test/bundle/output/umdDefaults/1.js
+++ b/test/bundle/output/umdDefaults/1.js
@@ -17,9 +17,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umdDefaults/10.js
+++ b/test/bundle/output/umdDefaults/10.js
@@ -17,7 +17,7 @@
 
 	'use strict';
 
-	class main__Foo {
+	class Foo {
 		constructor( str ) {
 			this.str = str;
 		}
@@ -26,8 +26,8 @@
 			return this.str;
 		}
 	}
-	var main__default = main__Foo;
+	var main = Foo;
 
-	return main__default;
+	return main;
 
 }));

--- a/test/bundle/output/umdDefaults/2.js
+++ b/test/bundle/output/umdDefaults/2.js
@@ -17,9 +17,9 @@
 
 	'use strict';
 
-	var foo__message = 'yes';
-	var foo__default = foo__message;
+	var message = 'yes';
+	var foo = message;
 
-	console.log( foo__default );
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umdDefaults/3.js
+++ b/test/bundle/output/umdDefaults/3.js
@@ -17,9 +17,9 @@
 
 	'use strict';
 
-	var foo__bar = 'yes';
-	var foo__default = foo__bar;
+	var bar = 'yes';
+	var foo = bar;
 
-	console.log( external__default( foo__default ) );
+	console.log( external__default( foo ) );
 
 }));

--- a/test/bundle/output/umdDefaults/4.js
+++ b/test/bundle/output/umdDefaults/4.js
@@ -17,10 +17,10 @@
 
 	'use strict';
 
-	var foo__answer = 42;
+	var answer = 42;
 
-	var main__default = foo__answer * 2;
+	var main = answer * 2;
 
-	return main__default;
+	return main;
 
 }));

--- a/test/bundle/output/umdDefaults/6.js
+++ b/test/bundle/output/umdDefaults/6.js
@@ -17,8 +17,8 @@
 
 	'use strict';
 
-	var message__default = 'this is a message';
+	var message = 'this is a message';
 
-	console.log( message__default );
+	console.log( message );
 
 }));

--- a/test/bundle/output/umdDefaults/7.js
+++ b/test/bundle/output/umdDefaults/7.js
@@ -17,14 +17,14 @@
 
 	'use strict';
 
-	var foo__default = 'this is foo';
+	var foo = 'this is foo';
 
-	function main__logFoo () {
-		console.log( foo__default );
+	function logFoo () {
+		console.log( foo );
 	}
 
-	function main__logBar () {
-		console.log( bar__default );
+	function logBar () {
+		console.log( bar );
 	}
 
 }));

--- a/test/es6-module-transpiler-tests/bundled-output/bindings.js
+++ b/test/es6-module-transpiler-tests/bundled-output/bindings.js
@@ -4,16 +4,16 @@
 
   /* jshint esnext:true */
 
-  var exporter__count = 0;
+  var count = 0;
 
-  function exporter__incr() {
-    exporter__count++;
+  function incr() {
+    count++;
   }
 
 	/* jshint esnext:true */
 
-	assert.equal(exporter__count, 0);
-	exporter__incr();
-	assert.equal(exporter__count, 1);
+	assert.equal(count, 0);
+	incr();
+	assert.equal(count, 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/cycles-defaults.js
+++ b/test/es6-module-transpiler-tests/bundled-output/cycles-defaults.js
@@ -4,17 +4,17 @@
 
 	/* jshint esnext:true */
 
-	var b__default = { b: 2, get a() { return a__default.a; } };
+	var b = { b: 2, get a() { return a.a; } };
 
 	/* jshint esnext:true */
 
-	var a__default = { a: 1, get b() { return b__default.b; } };
+	var a = { a: 1, get b() { return b.b; } };
 
 	/* jshint esnext:true */
 
-	assert.equal(a__default.a, 1);
-	assert.equal(a__default.b, 2);
-	assert.equal(b__default.a, 1);
-	assert.equal(b__default.b, 2);
+	assert.equal(a.a, 1);
+	assert.equal(a.b, 2);
+	assert.equal(b.a, 1);
+	assert.equal(b.b, 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/cycles-immediate.js
+++ b/test/es6-module-transpiler-tests/bundled-output/cycles-immediate.js
@@ -4,8 +4,8 @@
 
  /* jshint esnext:true */
 
- function odds__nextOdd(n) {
-   return evens__isEven(n) ? n + 1 : n + 2;
+ function nextOdd(n) {
+   return isEven(n) ? n + 1 : n + 2;
  }
 
  /**
@@ -13,23 +13,23 @@
   * ensure that both this module and the 'evens' module eagerly use something
   * from the other.
   */
- var odds__isOdd = (function(isEven) {
+ var isOdd = (function(isEven) {
    return function(n) {
      return !isEven(n);
    };
- })(evens__isEven);
+ })(isEven);
 
  /* jshint esnext:true */
 
- var evens__nextEven = (function() {
+ var nextEven = (function() {
    return function(n) {
-     var no = odds__nextOdd(n);
+     var no = nextOdd(n);
      return (no === n + 2) ?
        no - 1 : no;
    };
- })(odds__nextOdd);
+ })(nextOdd);
 
- function evens__isEven(n) {
+ function isEven(n) {
    return n % 2 === 0;
  }
 
@@ -48,11 +48,11 @@
   * function declarations are available before what would be a module's
   * "execute" step, per the spec.
   */
- assert.equal(evens__nextEven(1), 2);
- assert.equal(odds__nextOdd(1), 3);
- assert.ok(odds__isOdd(1));
- assert.ok(!odds__isOdd(0));
- assert.ok(evens__isEven(0));
- assert.ok(!evens__isEven(1));
+ assert.equal(nextEven(1), 2);
+ assert.equal(nextOdd(1), 3);
+ assert.ok(isOdd(1));
+ assert.ok(!isOdd(0));
+ assert.ok(isEven(0));
+ assert.ok(!isEven(1));
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/cycles.js
+++ b/test/es6-module-transpiler-tests/bundled-output/cycles.js
@@ -4,25 +4,25 @@
 
   /* jshint esnext:true */
 
-  function b__geta() {
-    return a__a;
+  function geta() {
+    return a;
   }
 
-  var b__b = 2;
+  var b = 2;
 
   /* jshint esnext:true */
 
-  function a__getb() {
-    return b__b;
+  function getb() {
+    return b;
   }
 
-  var a__a = 1;
+  var a = 1;
 
 	/* jshint esnext:true */
 
-	assert.equal(b__geta(), 1);
-	assert.equal(a__a, 1);
-	assert.equal(a__getb(), 2);
-	assert.equal(b__b, 2);
+	assert.equal(geta(), 1);
+	assert.equal(a, 1);
+	assert.equal(getb(), 2);
+	assert.equal(b, 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/duplicate-import-fails.js
+++ b/test/es6-module-transpiler-tests/bundled-output/duplicate-import-fails.js
@@ -4,11 +4,11 @@
 
 	/* jshint esnext:true */
 
-	var exporter__a = 1;
+	var a = 1;
 
 	/* jshint esnext:true */
 
 	/* error: type=SyntaxError message="expected one declaration for `a`, at importer.js:7:14 but found 2" */
-	assert.equal(exporter__a, 1);
+	assert.equal(a, 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/duplicate-import-specifier-fails.js
+++ b/test/es6-module-transpiler-tests/bundled-output/duplicate-import-specifier-fails.js
@@ -4,11 +4,11 @@
 
 	/* jshint esnext:true */
 
-	var exporter__a = 1;
+	var a = 1;
 
 	/* jshint esnext:true */
 
 	/* error: type=SyntaxError message="expected one declaration for `a`, at importer.js:5:14 but found 2" */
-	assert.equal(exporter__a, 1);
+	assert.equal(a, 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/export-and-import-reference-share-var.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-and-import-reference-share-var.js
@@ -4,22 +4,22 @@
 
 	/* jshint esnext:true */
 
-	var first__a = 1;
-	assert.equal(first__a, 1);
+	var a = 1;
+	assert.equal(a, 1);
 
 	/* jshint esnext:true */
 
-	var second__a_ = first__a, second__b = 9, second__c = 'c';
+	var a_ = a, b = 9, c = 'c';
 
-	assert.equal(first__a, 1);
-	assert.equal(second__a_, 1);
-	assert.equal(second__b, 9);
-	assert.equal(second__c, 'c');
+	assert.equal(a, 1);
+	assert.equal(a_, 1);
+	assert.equal(b, 9);
+	assert.equal(c, 'c');
 
 
 
 	(function (__export) {
-		__export('b', function () { return second__b; });
+		__export('b', function () { return b; });
 	}(function (prop, get) {
 		Object.defineProperty(exports, prop, {
 			enumerable: true,

--- a/test/es6-module-transpiler-tests/bundled-output/export-default-function.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-default-function.js
@@ -4,13 +4,13 @@
 
   /* jshint esnext:true */
 
-  var fn1__default = function () {
+  var fn1 = function () {
     return 1;
   }
 
 	/* jshint esnext:true */
 
-	assert.equal(fn1__default(), 1);
-	assert.equal(fn1__default(), 1);
+	assert.equal(fn1(), 1);
+	assert.equal(fn1(), 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/export-default-named-function.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-default-named-function.js
@@ -2,16 +2,16 @@
 
   'use strict';
 
-  function exporter__foo() {
+  function foo() {
     return 1;
   }
-  var exporter__default = exporter__foo;
+  var exporter = foo;
 
-  function exporter__callsFoo() {
-    return exporter__foo();
+  function callsFoo() {
+    return foo();
   }
 
-	assert.strictEqual(exporter__default(), 1);
-	assert.strictEqual(exporter__callsFoo(), 1);
+	assert.strictEqual(exporter(), 1);
+	assert.strictEqual(callsFoo(), 1);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/export-default.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-default.js
@@ -4,28 +4,28 @@
 
   /* jshint esnext:true */
 
-  var value__a = 42;
+  var a = 42;
 
-  function value__change() {
-    value__a++;
+  function change() {
+    a++;
   }
 
-  assert.equal(value__a, 42);
-  var value__default = value__a;
+  assert.equal(a, 42);
+  var value = a;
 
   // Any replacement for the `export default` above needs to happen in the same
   // location. It cannot be done, say, at the end of the file. Otherwise the new
   // value of `a` will be used and will be incorrect.
-  value__a = 0;
-  assert.equal(value__a, 0);
+  a = 0;
+  assert.equal(a, 0);
 
   /* jshint esnext:true */
 
-  assert.equal(value__default, 42);
+  assert.equal(value, 42);
 
-  value__change();
+  change();
   assert.equal(
-    value__default,
+    value,
     42,
     'default export should not be bound'
   );

--- a/test/es6-module-transpiler-tests/bundled-output/export-function.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-function.js
@@ -4,13 +4,13 @@
 
   /* jshint esnext:true */
 
-  function exporter__foo() {
+  function foo() {
     return 121;
   }
-  assert.equal(exporter__foo(), 121);
+  assert.equal(foo(), 121);
 
 	/* jshint esnext:true */
 
-	assert.equal(exporter__foo(), 121);
+	assert.equal(foo(), 121);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/export-list.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-list.js
@@ -4,20 +4,20 @@
 
   /* jshint esnext:true */
 
-  var exporter__a = 1;
-  var exporter__b = 2;
+  var a = 1;
+  var b = 2;
 
-  function exporter__incr() {
-    var c = exporter__a++; // Capture `a++` to force us to use a temporary variable.
-    exporter__b++;
+  function incr() {
+    var c = a++; // Capture `a++` to force us to use a temporary variable.
+    b++;
   }
 
 	/* jshint esnext:true */
 
-	assert.equal(exporter__a, 1);
-	assert.equal(exporter__b, 2);
-	exporter__incr();
-	assert.equal(exporter__a, 2);
-	assert.equal(exporter__b, 3);
+	assert.equal(a, 1);
+	assert.equal(b, 2);
+	incr();
+	assert.equal(a, 2);
+	assert.equal(b, 3);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/export-mixins.js
+++ b/test/es6-module-transpiler-tests/bundled-output/export-mixins.js
@@ -2,10 +2,10 @@
 
 	'use strict';
 
-	var exporter__default = 1;
-	var exporter__bar = 2;
+	var exporter = 1;
+	var bar = 2;
 
-	assert.equal(exporter__default, 1);
-	assert.equal(exporter__bar, 2);
+	assert.equal(exporter, 1);
+	assert.equal(bar, 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/import-as.js
+++ b/test/es6-module-transpiler-tests/bundled-output/import-as.js
@@ -4,14 +4,14 @@
 
 	/* jshint esnext:true */
 
-	var exporter__a = 'a';
-	var exporter__b = 'b';
-	var exporter__default = 'DEF';
+	var a = 'a';
+	var b = 'b';
+	var exporter = 'DEF';
 
 	/* jshint esnext:true */
 
-	assert.equal(exporter__a, 'a');
-	assert.equal(exporter__b, 'b');
-	assert.equal(exporter__default, 'DEF');
+	assert.equal(a, 'a');
+	assert.equal(b, 'b');
+	assert.equal(exporter, 'DEF');
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/import-chain.js
+++ b/test/es6-module-transpiler-tests/bundled-output/import-chain.js
@@ -4,12 +4,12 @@
 
 	/* jshint esnext:true */
 
-	var first__value = 42;
+	var value = 42;
 
 	/* jshint esnext:true */
 
 	/* jshint esnext:true */
 
-	assert.equal(first__value, 42);
+	assert.equal(value, 42);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/import-not-exported.js
+++ b/test/es6-module-transpiler-tests/bundled-output/import-not-exported.js
@@ -5,10 +5,15 @@
 	/* jshint esnext:true */
 
 	var a = 1;
+	var __b = 2;
 	assert.equal(a, 1);
+	assert.equal(__b, 2);
 
 	/* jshint esnext:true */
 
 	assert.equal(a, 1);
+
+	// `b` was not exported from "exporter"
+	assert.equal(typeof b, 'undefined');
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/module-level-declarations.js
+++ b/test/es6-module-transpiler-tests/bundled-output/module-level-declarations.js
@@ -2,13 +2,13 @@
 
   'use strict';
 
-  var mod__a = 1;
+  var a = 1;
 
-  assert.equal(mod__a, 1);
-  assert.equal(mod__getA(), 1);
+  assert.equal(a, 1);
+  assert.equal(getA(), 1);
 
-  function mod__getA() {
-    return mod__a;
+  function getA() {
+    return a;
   }
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/named-function-expression.js
+++ b/test/es6-module-transpiler-tests/bundled-output/named-function-expression.js
@@ -2,14 +2,14 @@
 
 	'use strict';
 
-	var exporter__a = 1;
+	var a = 1;
 
-  var importer__getA = function importer__getA() {
+  var getA = function getA() {
     var a = 2;
     return a;
   };
 
-  assert.strictEqual(exporter__a, 1);
-  assert.strictEqual(importer__getA(), 2);
+  assert.strictEqual(a, 1);
+  assert.strictEqual(getA(), 2);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/namespaces.js
+++ b/test/es6-module-transpiler-tests/bundled-output/namespaces.js
@@ -3,15 +3,15 @@
 	'use strict';
 
 	var exporter = {
-		get a () { return exporter__a; },
-		get b () { return exporter__b; },
+		get a () { return a; },
+		get b () { return b; },
 		get default () { return exporter__default; }
 	};
 
 	/* jshint esnext:true */
 
-	var exporter__a = 'a';
-	var exporter__b = 'b';
+	var a = 'a';
+	var b = 'b';
 	var exporter__default = 'DEF';
 
   /* jshint esnext:true */
@@ -20,10 +20,10 @@
   assert.equal(exporter.b, 'b');
   assert.equal(exporter.a, 'a');
 
-  var importer__keys = [];
-  for (var importer__key in exporter) {
-    importer__keys.push(importer__key);
+  var keys = [];
+  for (var key in exporter) {
+    keys.push(key);
   }
-  assert.deepEqual(importer__keys.sort(), ['a', 'b', 'default']);
+  assert.deepEqual(keys.sort(), ['a', 'b', 'default']);
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/bundled-output/re-export-default-import.js
+++ b/test/es6-module-transpiler-tests/bundled-output/re-export-default-import.js
@@ -4,15 +4,15 @@
 
   /* jshint esnext:true */
 
-  function hi__hi() {
+  function hi() {
     return 'hi';
   }
-  var hi__default = hi__hi;
+  var hi = hi;
 
 	/* jshint esnext:true */
 
 	/* jshint esnext:true */
 
-	assert.equal(hi__default(), 'hi');
+	assert.equal(hi(), 'hi');
 
 }).call(global);

--- a/test/es6-module-transpiler-tests/input/import-not-exported/exporter.js
+++ b/test/es6-module-transpiler-tests/input/import-not-exported/exporter.js
@@ -1,0 +1,6 @@
+/* jshint esnext:true */
+
+export var a = 1;
+var b = 2;
+assert.equal(a, 1);
+assert.equal(b, 2);

--- a/test/es6-module-transpiler-tests/input/import-not-exported/importer.js
+++ b/test/es6-module-transpiler-tests/input/import-not-exported/importer.js
@@ -1,0 +1,7 @@
+/* jshint esnext:true */
+
+import { a, b } from './exporter';
+assert.equal(a, 1);
+
+// `b` was not exported from "exporter"
+assert.equal(typeof b, 'undefined');

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -79,7 +79,7 @@ module.exports = function () {
 					});
 
 					smc = new SourceMapConsumer( converted.map );
-					loc = smc.originalPositionFor({ line: 5, column: 20 });
+					loc = smc.originalPositionFor({ line: 5, column: 15 });
 
 					assert.equal( loc.line, 1 );
 					assert.equal( loc.column, 15 );


### PR DESCRIPTION
This is just a request for consideration, so treat it as such. All tests pass, but that doesn't mean I haven't missed something important. Lookin' for feedback!

The concept here is to do as little modification as possible to the original source, only doing so to avoid conflicts within a scope.

This also fixes an issue where all of the top-level scope is accessible, regardless of being exported. It patches this issue by modifying the names of non-exported top-level Identifiers within a module. See added test which fails before this diff.