### PR TITLE
Ensure exported class declarations are late.

### DIFF
--- a/esperanto.js
+++ b/esperanto.js
@@ -1734,7 +1734,7 @@
 						body.replace( x.start, x.end, defaultValue + '\nexports[\'default\'] = ' + x.name + ';' );
 					} else {
 						// export function answer () { return 42; }
-						shouldExportEarly[ x.name ] = true; // TODO what about `function foo () {}; export { foo }`?
+						shouldExportEarly[ x.name ] = x.type === 'namedFunction';
 						body.remove( x.start, x.valueStart );
 					}
 					return;

--- a/src/standalone/builders/strictMode/utils/transformBody.js
+++ b/src/standalone/builders/strictMode/utils/transformBody.js
@@ -38,7 +38,7 @@ export default function transformBody ( mod, body, options ) {
 					body.replace( x.start, x.end, defaultValue + '\nexports[\'default\'] = ' + x.name + ';' );
 				} else {
 					// export function answer () { return 42; }
-					shouldExportEarly[ x.name ] = true; // TODO what about `function foo () {}; export { foo }`?
+					shouldExportEarly[ x.name ] = x.type === 'namedFunction';
 					body.remove( x.start, x.valueStart );
 				}
 				return;

--- a/test/samples/exportClass.js
+++ b/test/samples/exportClass.js
@@ -1,0 +1,1 @@
+export class Point {}

--- a/test/strictMode/index.js
+++ b/test/strictMode/index.js
@@ -17,6 +17,7 @@ module.exports = function () {
 			//{ file: 'exportAnonFunction', description: 'transpiled anonymous default function exports' },
 			{ file: 'exportDefault', description: 'transpiles default exports' },
 			{ file: 'exportInlineFunction', description: 'transpiles named inline function exports' },
+			{ file: 'exportClass', description: 'transpiles named class exports as late exports' },
 			{ file: 'exportLet', description: 'transpiles named inline let exports' },
 			{ file: 'exportNamed', description: 'transpiles named exports' },
 			{ file: 'exportVar', description: 'transpiles named inline variable exports' },

--- a/test/strictMode/output/amd/exportClass.js
+++ b/test/strictMode/output/amd/exportClass.js
@@ -1,0 +1,9 @@
+define(['exports'], function (exports) {
+
+	'use strict';
+
+	class Point {}
+
+	exports.Point = Point;
+
+});

--- a/test/strictMode/output/cjs/exportClass.js
+++ b/test/strictMode/output/cjs/exportClass.js
@@ -1,0 +1,9 @@
+(function () {
+
+	'use strict';
+
+	class Point {}
+
+	exports.Point = Point;
+
+}).call(global);

--- a/test/strictMode/output/umd/exportClass.js
+++ b/test/strictMode/output/umd/exportClass.js
@@ -1,0 +1,25 @@
+(function (global, factory) {
+
+	'use strict';
+
+	if (typeof define === 'function' && define.amd) {
+		// export as AMD
+		define(['exports'], factory);
+	} else if (typeof module !== 'undefined' && module.exports && typeof require === 'function') {
+		// node/browserify
+		factory(exports);
+	} else {
+		// browser global
+		global.myModule = {};
+		factory(global.myModule);
+	}
+
+}(typeof window !== 'undefined' ? window : this, function (exports) {
+
+	'use strict';
+
+	class Point {}
+
+	exports.Point = Point;
+
+}));


### PR DESCRIPTION
Since class declarations do not hoist, assignment to an “exports” object must happen after the class declaration in the module body.