### PR TITLE
Allow for optional per-module pre-transform.

### DIFF
--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -63,7 +63,21 @@ export default function getBundle ( options ) {
 				}
 
 				throw err;
-			}).then( String ).then( function ( source ) {
+			}).then( function ( source ) {
+				source = String( source );
+				if ( options.transform ) {
+					var transform = options.transform;
+					var transformed = transform(source);
+					if ( !transformed ||
+						( typeof transformed !== 'string' &&
+							typeof transformed.then !== 'function' )) {
+						throw new Error( 'transform should return String or Promise' );
+					}
+					return transformed;
+				} else {
+					return source;
+				}
+			}).then( function ( source ) {
 				var module, promises;
 
 				module = getModule({


### PR DESCRIPTION
Use case: I want to use flow for type checking, but acorn (rightly) doesn't parse the type hints. I need to strip the typehints before calling esperanto. However, esperanto reads directly from disk. So now I must first build a temp directory and build a parallel type-hint-stripped src tree and provide that to esperanto. Yuk.

This change allows for a "transform" step, not too dissimilar from the same functionality in browserify. Now, instead of mucking with temp files, I can just provide a source to source function that does type hint stripping.

Because of it's placement, `options.transform` can return either a Promise or String.