### PR TITLE
test and fix for #37 - functions are always exported early in strict mod...

### DIFF
--- a/src/standalone/builders/strictMode/utils/transformBody.js
+++ b/src/standalone/builders/strictMode/utils/transformBody.js
@@ -52,10 +52,6 @@ export default function transformBody ( mod, body, options ) {
 					body.insert( x.end, `\nexports['default'] = ${x.name};` );
 				} else {
 					// export function answer () { return 42; }
-					if ( x.type === 'namedFunction' ) {
-						shouldExportEarly[ x.name ] = true;
-					}
-
 					body.remove( x.start, x.valueStart );
 				}
 				return;
@@ -85,7 +81,9 @@ export default function transformBody ( mod, body, options ) {
 		if ( chains.hasOwnProperty( name ) ) {
 			// special case - a binding from another module
 			earlyExports.push( `Object.defineProperty(exports, '${exportAs}', { get: function () { return ${chains[name]}; }});` );
-		} else if ( shouldExportEarly.hasOwnProperty( name ) ) {
+		} else if ( ~mod.ast._topLevelFunctionNames.indexOf( name ) ) {
+			// functions should be exported early, in
+			// case of cyclic dependencies
 			earlyExports.push( `exports.${exportAs} = ${name};` );
 		} else if ( !alreadyExported.hasOwnProperty( name ) ) {
 			lateExports.push( `exports.${exportAs} = ${name};` );

--- a/src/utils/ast/annotate.js
+++ b/src/utils/ast/annotate.js
@@ -36,7 +36,7 @@ Scope.prototype = {
 };
 
 export default function annotateAst ( ast ) {
-	var scope = new Scope(), blockScope = new Scope(), declared = {}, templateLiteralRanges = [];
+	var scope = new Scope(), blockScope = new Scope(), declared = {}, topLevelFunctionNames = [], templateLiteralRanges = [];
 
 	estraverse.traverse( ast, {
 		enter: function ( node ) {
@@ -53,6 +53,12 @@ export default function annotateAst ( ast ) {
 				case 'FunctionDeclaration':
 					if ( node.id ) {
 						addToScope( node );
+
+						// If this is the root scope, this may need to be
+						// exported early, so we make a note of it
+						if ( !scope.parent ) {
+							topLevelFunctionNames.push( node.id.name );
+						}
 					}
 
 					scope = node._scope = new Scope({
@@ -122,6 +128,7 @@ export default function annotateAst ( ast ) {
 	ast._scope = scope;
 	ast._blockScope = blockScope;
 	ast._topLevelNames = ast._scope.names.concat( ast._blockScope.names );
+	ast._topLevelFunctionNames = topLevelFunctionNames;
 	ast._declared = declared;
 	ast._templateLiteralRanges = templateLiteralRanges;
 }

--- a/test/es6-module-transpiler-tests/output/export-list/exporter.js
+++ b/test/es6-module-transpiler-tests/output/export-list/exporter.js
@@ -2,6 +2,8 @@
 
   'use strict';
 
+  exports.incr = incr;
+
   /* jshint esnext:true */
 
   var a = 1;
@@ -14,6 +16,5 @@
 
   exports.a = a;
   exports.b = b;
-  exports.incr = incr;
 
 }).call(global);

--- a/test/samples/exportNamedFunction.js
+++ b/test/samples/exportNamedFunction.js
@@ -1,0 +1,5 @@
+function foo() {}
+function bar() {}
+function baz() {}
+
+export { foo, bar, baz };

--- a/test/strictMode/index.js
+++ b/test/strictMode/index.js
@@ -31,7 +31,8 @@ module.exports = function () {
 			{ file: 'clashingNames', description: 'avoids naming collisions' },
 			{ file: 'shadowedImport', description: 'handles shadowed imports' },
 			{ file: 'constructor', description: 'handles `constructor` edge case' },
-			{ file: 'namedAmdModule', description: 'creates a named AMD module if amdName is passed' }
+			{ file: 'namedAmdModule', description: 'creates a named AMD module if amdName is passed' },
+			{ file: 'exportNamedFunction', description: 'named functions are exported early' }
 		];
 
 		tests.forEach( function ( t ) {

--- a/test/strictMode/output/amd/exportNamedFunction.js
+++ b/test/strictMode/output/amd/exportNamedFunction.js
@@ -1,0 +1,13 @@
+define(['exports'], function (exports) {
+
+	'use strict';
+
+	exports.foo = foo;
+	exports.bar = bar;
+	exports.baz = baz;
+
+	function foo() {}
+	function bar() {}
+	function baz() {}
+
+});

--- a/test/strictMode/output/cjs/exportNamedFunction.js
+++ b/test/strictMode/output/cjs/exportNamedFunction.js
@@ -1,0 +1,13 @@
+(function () {
+
+	'use strict';
+
+	exports.foo = foo;
+	exports.bar = bar;
+	exports.baz = baz;
+
+	function foo() {}
+	function bar() {}
+	function baz() {}
+
+}).call(global);

--- a/test/strictMode/output/umd/exportNamedFunction.js
+++ b/test/strictMode/output/umd/exportNamedFunction.js
@@ -1,0 +1,29 @@
+(function (global, factory) {
+
+	'use strict';
+
+	if (typeof define === 'function' && define.amd) {
+		// export as AMD
+		define(['exports'], factory);
+	} else if (typeof module !== 'undefined' && module.exports && typeof require === 'function') {
+		// node/browserify
+		factory(exports);
+	} else {
+		// browser global
+		global.myModule = {};
+		factory(global.myModule);
+	}
+
+}(typeof window !== 'undefined' ? window : this, function (exports) {
+
+	'use strict';
+
+	exports.foo = foo;
+	exports.bar = bar;
+	exports.baz = baz;
+
+	function foo() {}
+	function bar() {}
+	function baz() {}
+
+}));


### PR DESCRIPTION
@eventualbuddha have I understood this (#37) correctly, that functions should always be exported early? Basically an extension of [this es6-module-transpiler test](https://github.com/esperantojs/esperanto/tree/master/test/es6-module-transpiler-tests/input/cycles-immediate)