### PR TITLE
Provide path to custom transform

### DIFF
--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -67,7 +67,7 @@ export default function getBundle ( options ) {
 				source = String( source );
 				if ( options.transform ) {
 					var transform = options.transform;
-					var transformed = transform(source);
+					var transformed = transform( source, modulePath );
 					if ( !transformed ||
 						( typeof transformed !== 'string' &&
 							typeof transformed.then !== 'function' )) {


### PR DESCRIPTION
In case the transformer needs to be aware of where the file lives. For example, if it's transforming relative paths found in the file, this can be important.