### PR TITLE
Cleanup builders

### DIFF
--- a/src/bundler/builders/defaultsMode/amd.js
+++ b/src/bundler/builders/defaultsMode/amd.js
@@ -4,23 +4,18 @@ import packageResult from '../../../utils/packageResult';
 var introTemplate = template( 'define(<%= amdName %><%= amdDeps %>function (<%= names %>) {\n\n\t\'use strict\';\n\n' );
 
 export default function amd ( bundle, body, options ) {
-	var intro,
-		indentStr,
-		defaultName;
-
-	indentStr = body.getIndentString();
-
-	if ( defaultName = bundle.entryModule.identifierReplacements.default ) {
-		body.append( `\n\n${indentStr}return ${defaultName};` );
+	var defaultName = bundle.entryModule.identifierReplacements.default;
+	if ( defaultName ) {
+		body.append( `\n\nreturn ${defaultName};` );
 	}
 
-	intro = introTemplate({
+	var intro = introTemplate({
 		amdName: options.amdName ? `'${options.amdName}', ` : '',
 		amdDeps: bundle.externalModules.length ? '[' + bundle.externalModules.map( quoteId ).join( ', ' ) + '], ' : '',
 		names: bundle.externalModules.map( m => bundle.uniqueNames[ m.id ] + '__default' ).join( ', ' )
-	}).replace( /\t/g, indentStr );
+	}).replace( /\t/g, body.getIndentString() );
 
-	body.prepend( intro ).trim().append( '\n\n});' );
+	body.indent().prepend( intro ).trimLines().append( '\n\n});' );
 	return packageResult( body, options, 'toAmd', true );
 }
 

--- a/src/bundler/builders/defaultsMode/cjs.js
+++ b/src/bundler/builders/defaultsMode/cjs.js
@@ -1,29 +1,22 @@
 import packageResult from 'utils/packageResult';
 
 export default function cjs ( bundle, body, options ) {
-	var importBlock,
-		x,
-		intro,
-		indentStr,
-		defaultName;
-
-	indentStr = body.getIndentString();
-
-	importBlock = bundle.externalModules.map( x => {
+	var importBlock = bundle.externalModules.map( x => {
 		var name = bundle.uniqueNames[ x.id ];
-		return indentStr + `var ${name}__default = require('${x.id}');`;
+		return `var ${name}__default = require('${x.id}');`;
 	}).join( '\n' );
 
 	if ( importBlock ) {
 		body.prepend( importBlock + '\n\n' );
 	}
 
-	if ( defaultName = bundle.entryModule.identifierReplacements.default ) {
-		body.append( `\n\n${indentStr}module.exports = ${defaultName};` );
+	var defaultName = bundle.entryModule.identifierReplacements.default;
+	if ( defaultName ) {
+		body.append( `\n\nmodule.exports = ${defaultName};` );
 	}
 
-	intro = '(function () {\n\n' + indentStr + "'use strict';\n\n";
+	body.prepend("'use strict';\n\n");
 
-	body.prepend( intro ).trim().append( '\n\n}).call(global);' );
+	body.indent().prepend('(function () {\n\n').trimLines().append('\n\n}).call(global);');
 	return packageResult( body, options, 'toCjs', true );
 }

--- a/src/bundler/builders/defaultsMode/umd.js
+++ b/src/bundler/builders/defaultsMode/umd.js
@@ -8,10 +8,14 @@ export default function umd ( bundle, body, options ) {
 	}
 
 	var entry = bundle.entryModule;
-	var indentStr = body.getIndentString();
 
 	var importPaths = bundle.externalModules.map( getId );
 	var importNames = importPaths.map( path => bundle.uniqueNames[ path ] );
+
+	var defaultName = entry.identifierReplacements.default;
+	if ( defaultName ) {
+		body.append( `\n\nreturn ${defaultName};` );
+	}
 
 	var intro = defaultUmdIntro({
 		hasImports: bundle.externalModules.length > 0,
@@ -23,16 +27,9 @@ export default function umd ( bundle, body, options ) {
 
 		amdName: options.amdName,
 		name: options.name
-	}, indentStr );
+	}, body.getIndentString() );
 
-	body.prepend( intro ).trim();
-
-	var defaultName;
-	if ( ( defaultName = entry.identifierReplacements.default ) ) {
-		body.append( `\n\n${indentStr}return ${defaultName};` );
-	}
-
-	body.append('\n\n}));');
+	body.indent().prepend( intro ).trimLines().append('\n\n}));');
 
 	return packageResult( body, options, 'toUmd', true );
 }

--- a/src/bundler/builders/strictMode/amd.js
+++ b/src/bundler/builders/strictMode/amd.js
@@ -4,22 +4,18 @@ import { getId, quote } from 'utils/mappers';
 import getExternalDefaults from './utils/getExternalDefaults';
 import getExportBlock from './utils/getExportBlock';
 
-var introTemplate;
+var introTemplate = template( 'define(<%= amdName %><%= amdDeps %>function (<%= names %>) {\n\n\t\'use strict\';\n\n' );
 
 export default function amd ( bundle, body, options ) {
-	var externalDefaults = getExternalDefaults( bundle ),
-		defaultsBlock,
-		entry = bundle.entryModule,
-		importIds = bundle.externalModules.map( getId ),
-		importNames = importIds.map( id => bundle.uniqueNames[ id ] ),
-		intro,
-		indentStr;
+	var externalDefaults = getExternalDefaults( bundle );
+	var entry = bundle.entryModule;
 
-	indentStr = body.getIndentString();
+	var importIds = bundle.externalModules.map( getId );
+	var importNames = importIds.map( id => bundle.uniqueNames[ id ] );
 
 	if ( externalDefaults.length ) {
-		defaultsBlock = externalDefaults.map( name => {
-			return indentStr + `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
+		var defaultsBlock = externalDefaults.map( name => {
+			return `var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 		}).join( '\n' );
 
 		body.prepend( defaultsBlock + '\n\n' );
@@ -30,18 +26,16 @@ export default function amd ( bundle, body, options ) {
 		importNames.unshift( 'exports' );
 
 		if ( entry.defaultExport ) {
-			body.append( '\n\n' + getExportBlock( entry, indentStr ) );
+			body.append( '\n\n' + getExportBlock( entry ) );
 		}
 	}
 
-	intro = introTemplate({
+	var intro = introTemplate({
 		amdName: options.amdName ? `'${options.amdName}', ` : '',
 		amdDeps: importIds.length ? '[' + importIds.map( quote ).join( ', ' ) + '], ' : '',
 		names: importNames.join( ', ' )
-	}).replace( /\t/g, indentStr );
+	}).replace( /\t/g, body.getIndentString() );
 
-	body.prepend( intro ).trim().append( '\n\n});' );
+	body.indent().prepend( intro ).trimLines().append( '\n\n});' );
 	return packageResult( body, options, 'toAmd', true );
 }
-
-introTemplate = template( 'define(<%= amdName %><%= amdDeps %>function (<%= names %>) {\n\n\t\'use strict\';\n\n' );

--- a/src/bundler/builders/strictMode/cjs.js
+++ b/src/bundler/builders/strictMode/cjs.js
@@ -3,20 +3,15 @@ import getExportBlock from './utils/getExportBlock';
 import getExternalDefaults from './utils/getExternalDefaults';
 
 export default function cjs ( bundle, body, options ) {
-	var externalDefaults = getExternalDefaults( bundle ),
-		importBlock,
-		entry = bundle.entryModule,
-		intro,
-		indentStr;
+	var externalDefaults = getExternalDefaults( bundle );
+	var entry = bundle.entryModule;
 
-	indentStr = body.getIndentString();
-
-	importBlock = bundle.externalModules.map( x => {
+	var importBlock = bundle.externalModules.map( x => {
 		var name = bundle.uniqueNames[ x.id ],
-			statement = `${indentStr}var ${name} = require('${x.id}');`;
+			statement = `var ${name} = require('${x.id}');`;
 
 		if ( ~externalDefaults.indexOf( name ) ) {
-			statement += `\n${indentStr}var ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
+			statement += `\nvar ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`;
 		}
 
 		return statement;
@@ -27,11 +22,11 @@ export default function cjs ( bundle, body, options ) {
 	}
 
 	if ( entry.defaultExport ) {
-		body.append( '\n\n' + getExportBlock( entry, indentStr ) );
+		body.append( '\n\n' + getExportBlock( entry ) );
 	}
 
-	intro = '(function () {\n\n' + indentStr + "'use strict';\n\n";
+	body.prepend("'use strict';\n\n");
 
-	body.prepend( intro ).trim().append( '\n\n}).call(global);' );
+	body.indent().prepend('(function () {\n\n').trimLines().append('\n\n}).call(global);');
 	return packageResult( body, options, 'toCjs', true );
 }

--- a/src/bundler/builders/strictMode/umd.js
+++ b/src/bundler/builders/strictMode/umd.js
@@ -10,7 +10,6 @@ export default function umd ( bundle, body, options ) {
 	}
 
 	var entry = bundle.entryModule;
-	var indentStr = body.getIndentString();
 
 	var importPaths = bundle.externalModules.map( getId );
 	var importNames = importPaths.map( path => bundle.uniqueNames[ path ] );
@@ -25,15 +24,13 @@ export default function umd ( bundle, body, options ) {
 
 		amdName: options.amdName,
 		name: options.name
-	}, indentStr );
-
-	body.prepend( intro ).trim();
+	}, body.getIndentString() );
 
 	if ( entry.exports.length && entry.defaultExport ) {
-		body.append( '\n\n' + getExportBlock( entry, indentStr ) );
+		body.append( '\n\n' + getExportBlock( entry ) );
 	}
 
-	body.append('\n\n}));');
+	body.indent().prepend( intro ).trimLines().append('\n\n}));');
 
 	return packageResult( body, options, 'toUmd', true );
 }

--- a/src/bundler/builders/strictMode/utils/getExportBlock.js
+++ b/src/bundler/builders/strictMode/utils/getExportBlock.js
@@ -1,4 +1,4 @@
-export default function getExportBlock ( entry, indentStr ) {
+export default function getExportBlock ( entry ) {
 	var name = entry.identifierReplacements.default;
-	return indentStr + `exports['default'] = ${name};`;
+	return `exports['default'] = ${name};`;
 }

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -40,5 +40,5 @@ export default function combine ( bundle ) {
 		});
 	});
 
-	bundle.body = body.indent();
+	bundle.body = body;
 }


### PR DESCRIPTION
Rather than indenting before sending to the bundle builders, indentation is now a responsibility of the bundle builders, reducing coupling.

Also cleans up the bundle builders a bit, hopefully making them a bit easier to read and reducing manual indentation.

Note, depends on a version of magic-string with https://github.com/Rich-Harris/magic-string/pull/2