### PR TITLE
Reshape UMD to respect module/export first.

### DIFF
--- a/src/bundler/builders/defaultsMode/umd.js
+++ b/src/bundler/builders/defaultsMode/umd.js
@@ -1,4 +1,5 @@
 import packageResult from 'utils/packageResult';
+import standaloneUmdIntro from 'utils/umd/standaloneUmdIntro';
 import defaultUmdIntro from 'utils/umd/defaultUmdIntro';
 import { getId } from 'utils/mappers';
 
@@ -9,25 +10,33 @@ export default function umd ( bundle, body, options ) {
 
 	var entry = bundle.entryModule;
 
-	var importPaths = bundle.externalModules.map( getId );
-	var importNames = importPaths.map( path => bundle.uniqueNames[ path ] );
+	var hasImports = bundle.externalModules.length > 0;
+	var hasExports = entry.exports.length > 0;
 
-	var defaultName = entry.identifierReplacements.default;
-	if ( defaultName ) {
-		body.append( `\n\nreturn ${defaultName};` );
+	var intro;
+	if (!hasImports && !hasExports) {
+		intro = standaloneUmdIntro({
+			amdName: options.amdName,
+		}, body.getIndentString() );
+	} else {
+
+		var defaultName = entry.identifierReplacements.default;
+		if ( defaultName ) {
+			body.append( `\n\nreturn ${defaultName};` );
+		}
+
+		var importPaths = bundle.externalModules.map( getId );
+		var importNames = importPaths.map( path => bundle.uniqueNames[ path ] );
+
+		intro = defaultUmdIntro({
+			hasExports,
+			importPaths,
+			importNames,
+			amdName: options.amdName,
+			name: options.name,
+			args: importNames.map( name => name + '__default' ),
+		}, body.getIndentString() );
 	}
-
-	var intro = defaultUmdIntro({
-		hasImports: bundle.externalModules.length > 0,
-		hasExports: entry.exports.length > 0,
-
-		importPaths: importPaths,
-		importNames: importNames,
-		args: importNames.map( name => name + '__default' ),
-
-		amdName: options.amdName,
-		name: options.name
-	}, body.getIndentString() );
 
 	body.indent().prepend( intro ).trimLines().append('\n\n}));');
 

--- a/src/standalone/builders/strictMode/umd.js
+++ b/src/standalone/builders/strictMode/umd.js
@@ -1,32 +1,36 @@
 import packageResult from 'utils/packageResult';
+import standaloneUmdIntro from 'utils/umd/standaloneUmdIntro';
 import strictUmdIntro from 'utils/umd/strictUmdIntro';
 import reorderImports from 'utils/reorderImports';
 import transformBody from './utils/transformBody';
 import getImportSummary from './utils/getImportSummary';
 
 export default function umd ( mod, body, options ) {
-	var importPaths,
-		importNames,
-		intro;
-
 	if ( !options.name ) {
 		throw new Error( 'You must supply a `name` option for UMD modules' );
 	}
 
 	reorderImports( mod.imports );
 
-	[ importPaths, importNames ] = getImportSummary( mod );
+	var [ importPaths, importNames ] = getImportSummary( mod );
 
-	intro = strictUmdIntro({
-		hasImports: mod.imports.length > 0,
-		hasExports: mod.exports.length > 0,
+	var hasImports = mod.imports.length > 0;
+	var hasExports = mod.exports.length > 0;
 
-		importPaths: importPaths,
-		importNames: importNames,
-
-		amdName: options.amdName,
-		name: options.name
-	}, body.getIndentString() );
+	var intro;
+	if (!hasImports && !hasExports) {
+		intro = standaloneUmdIntro({
+			amdName: options.amdName,
+		}, body.getIndentString() );
+	} else {
+		intro = strictUmdIntro({
+			hasExports,
+			importPaths,
+			importNames,
+			amdName: options.amdName,
+			name: options.name,
+		}, body.getIndentString() );
+	}
 
 	transformBody( mod, body, {
 		intro: intro,

--- a/src/utils/umd/standaloneUmdIntro.js
+++ b/src/utils/umd/standaloneUmdIntro.js
@@ -1,0 +1,16 @@
+export default function standaloneUmdIntro ( options, indentStr ) {
+	var amdName = options.amdName ?
+		"'" + options.amdName + "', " :
+		'';
+
+	var intro =
+`(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(${amdName}factory) :
+	factory()
+}(function () { 'use strict';
+
+`;
+
+	return intro.replace( /\t/g, indentStr );
+}

--- a/src/utils/umd/strictUmdIntro.js
+++ b/src/utils/umd/strictUmdIntro.js
@@ -1,39 +1,36 @@
 import { globalify, quote, req } from 'utils/mappers';
 
 export default function strictUmdIntro ( options, indentStr ) {
-	var intro, amdName, needsGlobal, defaultsBlock = '', amdDeps, cjsDeps, globalDeps, args, cjsDefine, globalDefine, nonAMDDefine;
+	var hasExports = options.hasExports;
 
-	amdName     = options.amdName ? `'${options.amdName}', ` : '';
-	needsGlobal = options.hasImports || options.hasExports;
+	var amdName = options.amdName ?
+		"'" + options.amdName + "', " :
+		'';
+	var amdDeps = options.hasExports || options.importPaths.length > 0 ?
+		'[' +
+			( options.hasExports ? [ 'exports' ] : [] ).concat( options.importPaths ).map( quote ).join( ', ' ) +
+		'], ' :
+		'';
+	var cjsDeps = ( options.hasExports ? [ 'exports' ] : [] ).concat( options.importPaths.map( req ) ).join( ', ' );
+	var globalDeps = ( options.hasExports ? [ `(global.${options.name} = {})` ] : [] )
+		.concat( options.importNames.map( globalify ) ).join( ', ' );
+	var args = ( options.hasExports ? [ 'exports' ] : [] ).concat( options.importNames ).join( ', ' );
 
-	amdDeps     = ( options.hasExports ? [ 'exports' ]    : [] ).concat( options.importPaths ).map( quote ).join( ', ' );
-	cjsDeps     = ( options.hasExports ? [ 'exports' ]    : [] ).concat( options.importPaths.map( req ) ).join( ', ' );
-	globalDeps  = ( options.hasExports ? [ options.name ] : [] ).concat( options.importNames ).map( globalify ).join( ', ' );
-
-	args        = ( options.hasExports ? [ 'exports' ]    : [] ).concat( options.importNames ).join( ', ' );
-
+	var defaultsBlock = '';
 	if ( options.externalDefaults && options.externalDefaults.length > 0 ) {
 		defaultsBlock = options.externalDefaults.map( name =>
 			`\tvar ${name}__default = ('default' in ${name} ? ${name}['default'] : ${name});`
-		).join( '\n' ) + '\n\n';
+		).join('\n') + '\n\n';
 	}
 
-	cjsDefine =`factory(${cjsDeps})`;
+	var intro =
+`(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(${cjsDeps}) :
+	typeof define === 'function' && define.amd ? define(${amdName}${amdDeps}factory) :
+	factory(${globalDeps})
+}(this, function (${args}) { 'use strict';
 
-	globalDefine = options.hasExports ?
-		`(global.${options.name} = {}, factory(${globalDeps}))` :
-		`factory(${globalDeps})`;
+${defaultsBlock}`
 
-	nonAMDDefine = cjsDefine === globalDefine ? globalDefine :
-		`typeof exports === 'object' ? ${cjsDefine} :\n\t${globalDefine}`;
-
-	intro =
-`(function (${needsGlobal ? 'global, ' : ''}factory) {
-	typeof define === 'function' && define.amd ? define(${amdName}${amdDeps ? '[' + amdDeps + '], ' : ''}factory) :
-	${nonAMDDefine}
-}(${needsGlobal ? 'this, ' : ''}function (${args}) { 'use strict';
-
-${defaultsBlock}`.replace( /\t/g, indentStr );
-
-	return intro;
+	return intro.replace( /\t/g, indentStr );
 }

--- a/test/bundle/output/umd/1.js
+++ b/test/bundle/output/umd/1.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/10.js
+++ b/test/bundle/output/umd/10.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	class Foo {

--- a/test/bundle/output/umd/11.js
+++ b/test/bundle/output/umd/11.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var foo = 1;

--- a/test/bundle/output/umd/14.js
+++ b/test/bundle/output/umd/14.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
 

--- a/test/bundle/output/umd/15.js
+++ b/test/bundle/output/umd/15.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.external)
 }(this, function (external) { 'use strict';
 

--- a/test/bundle/output/umd/16.js
+++ b/test/bundle/output/umd/16.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/17.js
+++ b/test/bundle/output/umd/17.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/18.js
+++ b/test/bundle/output/umd/18.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/19.js
+++ b/test/bundle/output/umd/19.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/2.js
+++ b/test/bundle/output/umd/2.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/20.js
+++ b/test/bundle/output/umd/20.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/test/bundle/output/umd/21.js
+++ b/test/bundle/output/umd/21.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/22.js
+++ b/test/bundle/output/umd/22.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	function foo () {

--- a/test/bundle/output/umd/24.js
+++ b/test/bundle/output/umd/24.js
@@ -1,5 +1,6 @@
 /* this is a banner */
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/25.js
+++ b/test/bundle/output/umd/25.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define('myModule', factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/26.js
+++ b/test/bundle/output/umd/26.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/27.js
+++ b/test/bundle/output/umd/27.js
@@ -1,4 +1,5 @@
 (function (factory) {
+  !(typeof exports === 'object' && typeof module !== 'undefined') &&
   typeof define === 'function' && define.amd ? define(factory) :
   factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/28.js
+++ b/test/bundle/output/umd/28.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/3.js
+++ b/test/bundle/output/umd/3.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.external)
 }(this, function (external) { 'use strict';
 

--- a/test/bundle/output/umd/4.js
+++ b/test/bundle/output/umd/4.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var answer = 42;

--- a/test/bundle/output/umd/5.js
+++ b/test/bundle/output/umd/5.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var one = 1;

--- a/test/bundle/output/umd/6.js
+++ b/test/bundle/output/umd/6.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('utils/external')) :
 	typeof define === 'function' && define.amd ? define(['utils/external'], factory) :
-	typeof exports === 'object' ? factory(require('utils/external')) :
 	factory(global.external)
 }(this, function (external) { 'use strict';
 

--- a/test/bundle/output/umd/7.js
+++ b/test/bundle/output/umd/7.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umd/8.js
+++ b/test/bundle/output/umd/8.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.ImplicitlyNamed)
 }(this, function (ImplicitlyNamed) { 'use strict';
 

--- a/test/bundle/output/umd/9.js
+++ b/test/bundle/output/umd/9.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.Correct)
 }(this, function (Correct) { 'use strict';
 

--- a/test/bundle/output/umdDefaults/1.js
+++ b/test/bundle/output/umdDefaults/1.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/10.js
+++ b/test/bundle/output/umdDefaults/10.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
 

--- a/test/bundle/output/umdDefaults/14.js
+++ b/test/bundle/output/umdDefaults/14.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.foo)
 }(this, function (foo__default) { 'use strict';
 

--- a/test/bundle/output/umdDefaults/16.js
+++ b/test/bundle/output/umdDefaults/16.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/17.js
+++ b/test/bundle/output/umdDefaults/17.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/18.js
+++ b/test/bundle/output/umdDefaults/18.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/19.js
+++ b/test/bundle/output/umdDefaults/19.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/2.js
+++ b/test/bundle/output/umdDefaults/2.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/20.js
+++ b/test/bundle/output/umdDefaults/20.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
 

--- a/test/bundle/output/umdDefaults/21.js
+++ b/test/bundle/output/umdDefaults/21.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/24.js
+++ b/test/bundle/output/umdDefaults/24.js
@@ -1,5 +1,6 @@
 /* this is a banner */
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/25.js
+++ b/test/bundle/output/umdDefaults/25.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define('myModule', factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/26.js
+++ b/test/bundle/output/umdDefaults/26.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/27.js
+++ b/test/bundle/output/umdDefaults/27.js
@@ -1,4 +1,5 @@
 (function (factory) {
+  !(typeof exports === 'object' && typeof module !== 'undefined') &&
   typeof define === 'function' && define.amd ? define(factory) :
   factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/28.js
+++ b/test/bundle/output/umdDefaults/28.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/3.js
+++ b/test/bundle/output/umdDefaults/3.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.external)
 }(this, function (external__default) { 'use strict';
 

--- a/test/bundle/output/umdDefaults/4.js
+++ b/test/bundle/output/umdDefaults/4.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
 

--- a/test/bundle/output/umdDefaults/6.js
+++ b/test/bundle/output/umdDefaults/6.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('utils/external')) :
 	typeof define === 'function' && define.amd ? define(['utils/external'], factory) :
-	typeof exports === 'object' ? factory(require('utils/external')) :
 	factory(global.external)
 }(this, function (external__default) { 'use strict';
 

--- a/test/bundle/output/umdDefaults/7.js
+++ b/test/bundle/output/umdDefaults/7.js
@@ -1,4 +1,5 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';

--- a/test/bundle/output/umdDefaults/8.js
+++ b/test/bundle/output/umdDefaults/8.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.ImplicitlyNamed)
 }(this, function (ImplicitlyNamed__default) { 'use strict';
 

--- a/test/bundle/output/umdDefaults/9.js
+++ b/test/bundle/output/umdDefaults/9.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	typeof exports === 'object' ? factory(require('external')) :
 	factory(global.Correct)
 }(this, function (Correct__default) { 'use strict';
 

--- a/test/fastMode/output/umd/banner.js
+++ b/test/fastMode/output/umd/banner.js
@@ -1,11 +1,9 @@
 /* this is a banner */
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['whatever'], factory) :
-	typeof exports === 'object' ? module.exports = factory(require('whatever')) :
 	global.myModule = factory(global.whatever)
 }(this, function (whatever) { 'use strict';
-
-	'use strict';
 
 	whatever();
 

--- a/test/fastMode/output/umd/bannerAndFooter.js
+++ b/test/fastMode/output/umd/bannerAndFooter.js
@@ -1,11 +1,9 @@
 /* this is a banner */
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['whatever'], factory) :
-	typeof exports === 'object' ? module.exports = factory(require('whatever')) :
 	global.myModule = factory(global.whatever)
 }(this, function (whatever) { 'use strict';
-
-	'use strict';
 
 	whatever();
 

--- a/test/fastMode/output/umd/clashingNames.js
+++ b/test/fastMode/output/umd/clashingNames.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	var foo = 'should not clash';
 

--- a/test/fastMode/output/umd/config/banner.js
+++ b/test/fastMode/output/umd/config/banner.js
@@ -1,9 +1,8 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';
-
-	'use strict';
 
 	module.exports = {
 		banner: '/* this is a banner */\n'

--- a/test/fastMode/output/umd/config/bannerAndFooter.js
+++ b/test/fastMode/output/umd/config/bannerAndFooter.js
@@ -1,9 +1,8 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';
-
-	'use strict';
 
 	module.exports = {
 		banner: '/* this is a banner */\n',

--- a/test/fastMode/output/umd/config/footer.js
+++ b/test/fastMode/output/umd/config/footer.js
@@ -1,9 +1,8 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';
-
-	'use strict';
 
 	module.exports = {
 		footer: '\n/* this is a footer */'

--- a/test/fastMode/output/umd/config/namedAmdModule.js
+++ b/test/fastMode/output/umd/config/namedAmdModule.js
@@ -1,9 +1,8 @@
 (function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
 	typeof define === 'function' && define.amd ? define(factory) :
 	factory()
 }(function () { 'use strict';
-
-	'use strict';
 
 	module.exports = {
 		amdName: 'myModule'

--- a/test/fastMode/output/umd/constructor.js
+++ b/test/fastMode/output/umd/constructor.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	return function () {
 		var constructor;

--- a/test/fastMode/output/umd/earlyExport.js
+++ b/test/fastMode/output/umd/earlyExport.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/fastMode/output/umd/emptyImport.js
+++ b/test/fastMode/output/umd/emptyImport.js
@@ -1,9 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? factory(require('foo'), require('polyfills')) :
 	factory(global.bar)
 }(this, function (bar) { 'use strict';
-
-	'use strict';
 
 }));

--- a/test/fastMode/output/umd/emptyImportWithDefaultExport.js
+++ b/test/fastMode/output/umd/emptyImportWithDefaultExport.js
@@ -1,10 +1,9 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? module.exports = factory(require('foo'), require('polyfills')) :
 	global.myModule = factory(global.foo)
 }(this, function (foo) { 'use strict';
 
-	'use strict';
 
 	return 'baz';
 

--- a/test/fastMode/output/umd/exportAnonFunction.js
+++ b/test/fastMode/output/umd/exportAnonFunction.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	return function () {
 		console.log( 'I am anonymous' );

--- a/test/fastMode/output/umd/exportDefault.js
+++ b/test/fastMode/output/umd/exportDefault.js
@@ -1,10 +1,9 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
 
-	'use strict';
 
 	return 'foo';
 

--- a/test/fastMode/output/umd/exportFunction.js
+++ b/test/fastMode/output/umd/exportFunction.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	typeof exports === 'object' ? module.exports = factory() :
 	global.myModule = factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	function foo ( str ) {
 		return str.toUpperCase();

--- a/test/fastMode/output/umd/footer.js
+++ b/test/fastMode/output/umd/footer.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['whatever'], factory) :
-	typeof exports === 'object' ? module.exports = factory(require('whatever')) :
 	global.myModule = factory(global.whatever)
 }(this, function (whatever) { 'use strict';
-
-	'use strict';
 
 	whatever();
 

--- a/test/fastMode/output/umd/importAll.js
+++ b/test/fastMode/output/umd/importAll.js
@@ -1,9 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('fs')) :
 	typeof define === 'function' && define.amd ? define(['fs'], factory) :
-	typeof exports === 'object' ? factory(require('fs')) :
 	factory(global.fs)
 }(this, function (fs) { 'use strict';
-
-	'use strict';
 
 }));

--- a/test/fastMode/output/umd/importDefault.js
+++ b/test/fastMode/output/umd/importDefault.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
-
-	'use strict';
 
 	console.log( foo );
 

--- a/test/fastMode/output/umd/multipleImports.js
+++ b/test/fastMode/output/umd/multipleImports.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(require('foo'), require('bar'), require('baz')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'bar', 'baz'], factory) :
-	typeof exports === 'object' ? module.exports = factory(require('foo'), require('bar'), require('baz')) :
 	global.myModule = factory(global.foo, global.bar, global.baz)
 }(this, function (foo, bar, baz) { 'use strict';
-
-	'use strict';
 
 	var qux = foo( bar( baz ) );
 

--- a/test/fastMode/output/umd/namedAmdModule.js
+++ b/test/fastMode/output/umd/namedAmdModule.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define('myModule', ['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
-
-	'use strict';
 
 	foo();
 

--- a/test/fastMode/output/umd/renamedImport.js
+++ b/test/fastMode/output/umd/renamedImport.js
@@ -1,9 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('fs')) :
 	typeof define === 'function' && define.amd ? define(['fs'], factory) :
-	typeof exports === 'object' ? factory(require('fs')) :
 	factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 }));

--- a/test/fastMode/output/umd/shadowedImport.js
+++ b/test/fastMode/output/umd/shadowedImport.js
@@ -1,10 +1,8 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory()
 }(this, function () { 'use strict';
-
-	'use strict';
 
 	a();
 	(function () {

--- a/test/fastMode/output/umd/trailingEmptyImport.js
+++ b/test/fastMode/output/umd/trailingEmptyImport.js
@@ -1,9 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? factory(require('foo'), require('polyfills')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
-
-	'use strict';
 
 }));

--- a/test/strictMode/output/umd/banner.js
+++ b/test/strictMode/output/umd/banner.js
@@ -1,8 +1,8 @@
 /* this is a banner */
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'whatever'], factory) :
-	typeof exports === 'object' ? factory(exports, require('whatever')) :
-	(global.myModule = {}, factory(global.myModule, global.whatever))
+	factory((global.myModule = {}), global.whatever)
 }(this, function (exports, whatever) { 'use strict';
 
 	whatever['default']();

--- a/test/strictMode/output/umd/bannerAndFooter.js
+++ b/test/strictMode/output/umd/bannerAndFooter.js
@@ -1,8 +1,8 @@
 /* this is a banner */
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'whatever'], factory) :
-	typeof exports === 'object' ? factory(exports, require('whatever')) :
-	(global.myModule = {}, factory(global.myModule, global.whatever))
+	factory((global.myModule = {}), global.whatever)
 }(this, function (exports, whatever) { 'use strict';
 
 	whatever['default']();

--- a/test/strictMode/output/umd/clashingNames.js
+++ b/test/strictMode/output/umd/clashingNames.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global._foo)
 }(this, function (_foo) { 'use strict';
 

--- a/test/strictMode/output/umd/constructor.js
+++ b/test/strictMode/output/umd/constructor.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports['default'] = function () {

--- a/test/strictMode/output/umd/earlyExport.js
+++ b/test/strictMode/output/umd/earlyExport.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports['default'] = foo;

--- a/test/strictMode/output/umd/emptyImport.js
+++ b/test/strictMode/output/umd/emptyImport.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? factory(require('foo'), require('polyfills')) :
 	factory(global.bar)
 }(this, function (bar) { 'use strict';
 

--- a/test/strictMode/output/umd/emptyImportWithDefaultExport.js
+++ b/test/strictMode/output/umd/emptyImportWithDefaultExport.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? factory(exports, require('foo'), require('polyfills')) :
-	(global.myModule = {}, factory(global.myModule, global.foo))
+	factory((global.myModule = {}), global.foo)
 }(this, function (exports, foo) { 'use strict';
 
 	exports['default'] = 'baz';

--- a/test/strictMode/output/umd/exportAnonFunction.js
+++ b/test/strictMode/output/umd/exportAnonFunction.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports['default'] = function () {

--- a/test/strictMode/output/umd/exportClass.js
+++ b/test/strictMode/output/umd/exportClass.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	class Point {}

--- a/test/strictMode/output/umd/exportDefault.js
+++ b/test/strictMode/output/umd/exportDefault.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports['default'] = 'foo';

--- a/test/strictMode/output/umd/exportFunction.js
+++ b/test/strictMode/output/umd/exportFunction.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	function foo ( str ) {

--- a/test/strictMode/output/umd/exportInlineFunction.js
+++ b/test/strictMode/output/umd/exportInlineFunction.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports.foo = foo;

--- a/test/strictMode/output/umd/exportLet.js
+++ b/test/strictMode/output/umd/exportLet.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	let answer = 41;

--- a/test/strictMode/output/umd/exportNamed.js
+++ b/test/strictMode/output/umd/exportNamed.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var foo = 'bar', answer = 42;

--- a/test/strictMode/output/umd/exportNamedFunction.js
+++ b/test/strictMode/output/umd/exportNamedFunction.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	exports.foo = foo;

--- a/test/strictMode/output/umd/exportVar.js
+++ b/test/strictMode/output/umd/exportVar.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	typeof exports === 'object' ? factory(exports) :
-	(global.myModule = {}, factory(global.myModule))
+	factory((global.myModule = {}))
 }(this, function (exports) { 'use strict';
 
 	var foo = 'bar';

--- a/test/strictMode/output/umd/footer.js
+++ b/test/strictMode/output/umd/footer.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('whatever')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'whatever'], factory) :
-	typeof exports === 'object' ? factory(exports, require('whatever')) :
-	(global.myModule = {}, factory(global.myModule, global.whatever))
+	factory((global.myModule = {}), global.whatever)
 }(this, function (exports, whatever) { 'use strict';
 
 	whatever['default']();

--- a/test/strictMode/output/umd/importAll.js
+++ b/test/strictMode/output/umd/importAll.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('fs')) :
 	typeof define === 'function' && define.amd ? define(['fs'], factory) :
-	typeof exports === 'object' ? factory(require('fs')) :
 	factory(global.fs)
 }(this, function (fs) { 'use strict';
 

--- a/test/strictMode/output/umd/importDefault.js
+++ b/test/strictMode/output/umd/importDefault.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
 

--- a/test/strictMode/output/umd/importNamed.js
+++ b/test/strictMode/output/umd/importNamed.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('baz')) :
 	typeof define === 'function' && define.amd ? define(['baz'], factory) :
-	typeof exports === 'object' ? factory(require('baz')) :
 	factory(global.baz)
 }(this, function (baz) { 'use strict';
 

--- a/test/strictMode/output/umd/mixedImports.js
+++ b/test/strictMode/output/umd/mixedImports.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('asap')) :
 	typeof define === 'function' && define.amd ? define(['asap'], factory) :
-	typeof exports === 'object' ? factory(require('asap')) :
 	factory(global.asap)
 }(this, function (asap) { 'use strict';
 

--- a/test/strictMode/output/umd/multipleImports.js
+++ b/test/strictMode/output/umd/multipleImports.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports, require('foo'), require('bar'), require('baz')) :
 	typeof define === 'function' && define.amd ? define(['exports', 'foo', 'bar', 'baz'], factory) :
-	typeof exports === 'object' ? factory(exports, require('foo'), require('bar'), require('baz')) :
-	(global.myModule = {}, factory(global.myModule, global.foo, global.bar, global.baz))
+	factory((global.myModule = {}), global.foo, global.bar, global.baz)
 }(this, function (exports, foo, bar, baz) { 'use strict';
 
 	var qux = foo['default']( bar['default']( baz['default'] ) );

--- a/test/strictMode/output/umd/namedAmdModule.js
+++ b/test/strictMode/output/umd/namedAmdModule.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define('myModule', ['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
 

--- a/test/strictMode/output/umd/renamedImport.js
+++ b/test/strictMode/output/umd/renamedImport.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('fs')) :
 	typeof define === 'function' && define.amd ? define(['fs'], factory) :
-	typeof exports === 'object' ? factory(require('fs')) :
 	factory(global.fs)
 }(this, function (fs) { 'use strict';
 

--- a/test/strictMode/output/umd/shadowedImport.js
+++ b/test/strictMode/output/umd/shadowedImport.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	typeof exports === 'object' ? factory(require('foo')) :
 	factory(global._foo)
 }(this, function (_foo) { 'use strict';
 

--- a/test/strictMode/output/umd/trailingEmptyImport.js
+++ b/test/strictMode/output/umd/trailingEmptyImport.js
@@ -1,6 +1,6 @@
 (function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('polyfills')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'polyfills'], factory) :
-	typeof exports === 'object' ? factory(require('foo'), require('polyfills')) :
 	factory(global.foo)
 }(this, function (foo) { 'use strict';
 


### PR DESCRIPTION
Ran into a problem with the UMD wrapper. Here's the scenario:

We wrap libraries in UMD to make them easier to deploy in any environment, however one common environment is CJS to AMD-compiler.

If a library is exported as UMD, but treated as CJS in a local environment, and then compiled to AMD (via a wrapper), then our UMD wrapper misidentifies the environment as AMD, when we want it to behave as CJS. define() is called from within define(), and the outer-most define() ends up thinking its module exports nothing, causing sad trombone music to play out of it's tiny 8-bit speakers.

In other words: AMD defines both "module"/"exports" and "define" where CJS defines only "module"/"exports". However, AMD environments do not globally define "module"/"exports" - only locally to a module definition, in which case they should be treated as CJS treats them.

What this means is that we actually want to detect "module"/"exports" first, falling back to detecting "define" (assuming a global level).