### PR TITLE
Support silly windows paths

### DIFF
--- a/src/bundler/combine/getUniqueNames.js
+++ b/src/bundler/combine/getUniqueNames.js
@@ -1,5 +1,5 @@
 import hasOwnProp from 'utils/hasOwnProp';
-import sanitize from 'utils/sanitize';
+import { default as sanitize, splitPath } from 'utils/sanitize';
 
 export default function getUniqueNames ( modules, externalModules, userNames ) {
 	var names = {}, used = {};
@@ -32,7 +32,7 @@ export default function getUniqueNames ( modules, externalModules, userNames ) {
 			return;
 		}
 
-		parts = mod.id.split( '/' );
+		parts = splitPath( mod.id );
 
 		i = parts.length;
 		while ( i-- ) {

--- a/src/bundler/utils/resolveId.js
+++ b/src/bundler/utils/resolveId.js
@@ -1,3 +1,5 @@
+import { splitPath } from 'utils/sanitize';
+
 /**
  * Resolves an importPath relative to the module that is importing it
  * @param {string} importPath - the (possibly relative) path of an imported module
@@ -10,8 +12,8 @@ export default function resolveId ( importPath, importerPath ) {
 	if ( importPath[0] !== '.' ) {
 		resolved = importPath;
 	} else {
-		importerParts = importerPath.split( '/' );
-		importParts = importPath.split( '/' );
+		importerParts = splitPath( importerPath );
+		importParts = splitPath( importPath );
 
 		importerParts.pop(); // get dirname
 		while ( importParts[0] === '..' ) {

--- a/src/standalone/getModuleNameHelper.js
+++ b/src/standalone/getModuleNameHelper.js
@@ -1,5 +1,5 @@
 import hasOwnProp from 'utils/hasOwnProp';
-import sanitize from 'utils/sanitize';
+import { default as sanitize, splitPath } from 'utils/sanitize';
 
 export default function getModuleNameHelper ( userFn, usedNames = {} ) {
 	var nameById = {}, getModuleName;
@@ -29,7 +29,7 @@ export default function getModuleNameHelper ( userFn, usedNames = {} ) {
 		}
 
 		else {
-			parts = moduleId.split( '/' );
+			parts = splitPath( moduleId );
 			i = parts.length;
 
 			do {

--- a/src/utils/packageResult.js
+++ b/src/utils/packageResult.js
@@ -1,3 +1,5 @@
+import { splitPath } from 'utils/sanitize';
+
 var warned = {};
 
 export default function packageResult ( body, options, methodName, isBundle ) {
@@ -25,7 +27,7 @@ export default function packageResult ( body, options, methodName, isBundle ) {
 			code += '\n//# sourceMa' + 'ppingURL=' + map.toUrl();
 			map = null;
 		} else {
-			code += '\n//# sourceMa' + 'ppingURL=./' + options.sourceMapFile.split( '/' ).pop() + '.map';
+			code += '\n//# sourceMa' + 'ppingURL=./' + splitPath( options.sourceMapFile ).pop() + '.map';
 		}
 	} else {
 		map = null;
@@ -48,8 +50,8 @@ export default function packageResult ( body, options, methodName, isBundle ) {
 function getRelativePath ( from, to ) {
 	var fromParts, toParts, i;
 
-	fromParts = from.split( '/' );
-	toParts = to.split( '/' );
+	fromParts = splitPath( from );
+	toParts = splitPath( to );
 
 	fromParts.pop(); // get dirname
 

--- a/src/utils/sanitize.js
+++ b/src/utils/sanitize.js
@@ -17,3 +17,8 @@ export default function sanitize ( name ) {
 
 	return name;
 }
+
+var pathSplitRE = /\/|\\/;
+export function splitPath ( path ) {
+	return path.split( pathSplitRE );
+}


### PR DESCRIPTION
Bloody windows and its backslashes. This should fix issues with bundling and relative imports. I don't really see a clean way to test this, but it passes the anecdotal check here for Ractive.