### PR TITLE
Error early when accessing properties on top-level `this`.

### DIFF
--- a/src/utils/ast/annotate.js
+++ b/src/utils/ast/annotate.js
@@ -93,6 +93,9 @@ export default function annotateAst ( ast ) {
 					break;
 
 				case 'MemberExpression':
+					if ( envDepth === 0 && node.object.type === 'ThisExpression' ) {
+						throw new Error('`this` at the top level is undefined');
+					}
 					!node.computed && ( node.property._skip = true );
 					break;
 

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -53,6 +53,8 @@ module.exports = function () {
 				{ entry: 'importer', dir: 'reassign-import-fails', expectedError: 'Cannot reassign imported binding `x`' },
 				{ entry: 'importer', dir: 'reassign-import-not-at-top-level-fails', expectedError: 'Cannot reassign imported binding `x`' },
 				{ entry: 'mod', dir: 'this-binding-undefined' },
+				{ entry: 'mod', dir: 'this-binding-get-early-error', expectedError: '`this` at the top level is undefined' },
+				{ entry: 'mod', dir: 'this-binding-set-early-error', expectedError: '`this` at the top level is undefined' },
 				{ entry: 'importer', dir: 'update-expression-of-import-fails', expectedError: 'Cannot reassign imported binding `a`' }
 			];
 

--- a/test/es6-module-transpiler-tests/input/this-binding-get-early-error/mod.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-get-early-error/mod.js
@@ -1,0 +1,1 @@
+this.notThere();

--- a/test/es6-module-transpiler-tests/input/this-binding-set-early-error/mod.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-set-early-error/mod.js
@@ -1,0 +1,1 @@
+this.notThere = function () {};


### PR DESCRIPTION
I'm not totally sure we should do this, but I figured I'd try it out and see.

Closes #44.