### PR TITLE
Prevent function expressions from triggering early-exports.

### DIFF
--- a/src/utils/ast/annotate.js
+++ b/src/utils/ast/annotate.js
@@ -64,7 +64,7 @@ export default function annotateAst ( ast ) {
 
 						// If this is the root scope, this may need to be
 						// exported early, so we make a note of it
-						if ( !scope.parent ) {
+						if ( !scope.parent && node.type === 'FunctionDeclaration' ) {
 							topLevelFunctionNames.push( node.id.name );
 						}
 					}

--- a/test/samples/exportNamedCollidesWithFunctionExpression/_config.js
+++ b/test/samples/exportNamedCollidesWithFunctionExpression/_config.js
@@ -1,0 +1,5 @@
+module.exports = {
+	description: 'does not interpret named function expressions as early-exportable',
+	amdName: 'foo',
+	strict: true
+};

--- a/test/samples/exportNamedCollidesWithFunctionExpression/source.js
+++ b/test/samples/exportNamedCollidesWithFunctionExpression/source.js
@@ -1,0 +1,7 @@
+var foo = "bar";
+
+if (false) {
+	someFunction = function foo() {  };
+}
+
+export { foo };

--- a/test/strictMode/output/amd/exportNamedCollidesWithFunctionExpression.js
+++ b/test/strictMode/output/amd/exportNamedCollidesWithFunctionExpression.js
@@ -1,0 +1,13 @@
+define('foo', ['exports'], function (exports) {
+
+	'use strict';
+
+	var foo = "bar";
+
+	if (false) {
+		someFunction = function foo() {  };
+	}
+
+	exports.foo = foo;
+
+});

--- a/test/strictMode/output/cjs/exportNamedCollidesWithFunctionExpression.js
+++ b/test/strictMode/output/cjs/exportNamedCollidesWithFunctionExpression.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = "bar";
+
+if (false) {
+	someFunction = function foo() {  };
+}
+
+exports.foo = foo;

--- a/test/strictMode/output/umd/exportNamedCollidesWithFunctionExpression.js
+++ b/test/strictMode/output/umd/exportNamedCollidesWithFunctionExpression.js
@@ -1,0 +1,15 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define('foo', ['exports'], factory) :
+	factory((global.myModule = {}))
+}(this, function (exports) { 'use strict';
+
+	var foo = "bar";
+
+	if (false) {
+		someFunction = function foo() {  };
+	}
+
+	exports.foo = foo;
+
+}));


### PR DESCRIPTION
When looking for top-level function names we need to only look at nodes that create bindings in the local scope, which are function declarations.

Closes #73.