### PR TITLE
Allow using `exports` as a top-level binding name.

### DIFF
--- a/src/standalone/builders/strictMode/amd.js
+++ b/src/standalone/builders/strictMode/amd.js
@@ -4,6 +4,7 @@ import { resolveAgainst } from 'utils/resolveId';
 import transformBody from './utils/transformBody';
 import getImportSummary from './utils/getImportSummary';
 import { quote } from 'utils/mappers';
+import getExportObjectName from 'utils/getExportObjectName';
 
 var introTemplate;
 
@@ -16,9 +17,11 @@ export default function amd ( mod, body, options ) {
 
 	[ importPaths, importNames ] = getImportSummary( mod );
 
+	var exportObject = getExportObjectName( mod );
+
 	if ( mod.exports.length ) {
 		importPaths.unshift( 'exports' );
-		importNames.unshift( 'exports' );
+		importNames.unshift( exportObject );
 	}
 
 	intro = introTemplate({
@@ -29,7 +32,8 @@ export default function amd ( mod, body, options ) {
 
 	transformBody( mod, body, {
 		intro: intro,
-		outro: '\n\n});'
+		outro: '\n\n});',
+		exportObject: exportObject,
 	});
 
 	return packageResult( body, options, 'toAmd' );

--- a/src/standalone/builders/strictMode/cjs.js
+++ b/src/standalone/builders/strictMode/cjs.js
@@ -2,6 +2,7 @@ import packageResult from 'utils/packageResult';
 import hasOwnProp from 'utils/hasOwnProp';
 import transformBody from './utils/transformBody';
 import { req } from 'utils/mappers';
+import getExportObjectName from 'utils/getExportObjectName';
 
 export default function cjs ( mod, body, options ) {
 	var importBlock, seen = {};
@@ -24,9 +25,19 @@ export default function cjs ( mod, body, options ) {
 		return replacement;
 	}).filter( Boolean ).join( '\n' );
 
+	var exportObject = getExportObjectName(mod);
+
 	transformBody( mod, body, {
 		header: importBlock,
+		exportObject: exportObject,
 	});
+
+	if ( exportObject !== 'exports' ) {
+		body.indent();
+		body.trimLines();
+		body.prepend( `function (${exportObject}) {\n` );
+		body.append( '\n}( exports );\n' );
+	}
 
 	body.prepend( "'use strict';\n\n" ).trimLines();
 

--- a/src/standalone/builders/strictMode/umd.js
+++ b/src/standalone/builders/strictMode/umd.js
@@ -4,6 +4,7 @@ import strictUmdIntro from 'utils/umd/strictUmdIntro';
 import requireName from 'utils/umd/requireName';
 import transformBody from './utils/transformBody';
 import getImportSummary from './utils/getImportSummary';
+import getExportObjectName from 'utils/getExportObjectName';
 
 export default function umd ( mod, body, options ) {
 	requireName( options );
@@ -12,6 +13,7 @@ export default function umd ( mod, body, options ) {
 
 	var hasImports = mod.imports.length > 0;
 	var hasExports = mod.exports.length > 0;
+	var exportObject = getExportObjectName( mod );
 
 	var intro;
 	if (!hasImports && !hasExports) {
@@ -26,12 +28,14 @@ export default function umd ( mod, body, options ) {
 			amdName: options.amdName,
 			absolutePaths: options.absolutePaths,
 			name: options.name,
+			exportObject,
 		}, body.getIndentString() );
 	}
 
 	transformBody( mod, body, {
 		intro: intro,
-		outro: '\n\n}));'
+		outro: '\n\n}));',
+		exportObject,
 	});
 
 	return packageResult( body, options, 'toUmd' );

--- a/src/utils/getExportObjectName.js
+++ b/src/utils/getExportObjectName.js
@@ -1,0 +1,9 @@
+export default function getExportObjectName( mod ) {
+	var exportObjectName = 'exports';
+
+	while ( mod.ast._scope.contains( exportObjectName ) ) {
+		exportObjectName = `_${exportObjectName}`;
+	}
+
+	return exportObjectName;
+}

--- a/src/utils/umd/strictUmdIntro.js
+++ b/src/utils/umd/strictUmdIntro.js
@@ -1,8 +1,10 @@
 import { globalify, quote, req } from 'utils/mappers';
 import { resolveAgainst } from 'utils/resolveId';
+import getExportObjectName from 'utils/getExportObjectName';
 
 export default function strictUmdIntro ( options, indentStr ) {
 	var hasExports = options.hasExports;
+	var exportObject = options.exportObject || 'exports';
 
 	var amdName = options.amdName ?
 		"'" + options.amdName + "', " :
@@ -15,7 +17,7 @@ export default function strictUmdIntro ( options, indentStr ) {
 	var cjsDeps = ( hasExports ? [ 'exports' ] : [] ).concat( options.importPaths.map( req ) ).join( ', ' );
 	var globalDeps = ( hasExports ? [ `(global.${options.name} = {})` ] : [] )
 		.concat( options.importNames.map( globalify ) ).join( ', ' );
-	var args = ( hasExports ? [ 'exports' ] : [] ).concat( options.importNames ).join( ', ' );
+	var args = ( hasExports ? [ exportObject ] : [] ).concat( options.importNames ).join( ', ' );
 
 	var defaultsBlock = '';
 	if ( options.externalDefaults && options.externalDefaults.length > 0 ) {

--- a/test/fastMode/output/amd/exportsObjectCollision.js
+++ b/test/fastMode/output/amd/exportsObjectCollision.js
@@ -1,0 +1,9 @@
+define(function () {
+
+	'use strict';
+
+	var exports = {};
+
+	return exports;
+
+});

--- a/test/fastMode/output/cjs/exportsObjectCollision.js
+++ b/test/fastMode/output/cjs/exportsObjectCollision.js
@@ -1,0 +1,4 @@
+'use strict';
+
+var exports = {};
+module.exports = exports;

--- a/test/fastMode/output/umd/exportsObjectCollision.js
+++ b/test/fastMode/output/umd/exportsObjectCollision.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof define === 'function' && define.amd ? define(factory) :
+	global.myModule = factory()
+}(this, function () { 'use strict';
+
+	var exports = {};
+
+	return exports;
+
+}));

--- a/test/samples/exportsObjectCollision/_config.js
+++ b/test/samples/exportsObjectCollision/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'renames the exports object if an exports binding is declared'
+};

--- a/test/samples/exportsObjectCollision/source.js
+++ b/test/samples/exportsObjectCollision/source.js
@@ -1,0 +1,2 @@
+var exports = {};
+export default exports;

--- a/test/strictMode/output/amd/exportsObjectCollision.js
+++ b/test/strictMode/output/amd/exportsObjectCollision.js
@@ -1,0 +1,8 @@
+define(['exports'], function (_exports) {
+
+	'use strict';
+
+	var exports = {};
+	_exports['default'] = exports;
+
+});

--- a/test/strictMode/output/cjs/exportsObjectCollision.js
+++ b/test/strictMode/output/cjs/exportsObjectCollision.js
@@ -1,0 +1,6 @@
+'use strict';
+
+function (_exports) {
+	var exports = {};
+	_exports['default'] = exports;
+}( exports );

--- a/test/strictMode/output/umd/exportsObjectCollision.js
+++ b/test/strictMode/output/umd/exportsObjectCollision.js
@@ -1,0 +1,10 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	factory((global.myModule = {}))
+}(this, function (_exports) { 'use strict';
+
+	var exports = {};
+	_exports['default'] = exports;
+
+}));


### PR DESCRIPTION
This works with everything except UMD, will look at that later. Thoughts on strategy, specifically the IIFE in CJS?

Fixes #74.