### PR TITLE
fixes a bug with default export assignments that clash

### DIFF
--- a/src/bundler/combine/populateIdentifierReplacements.js
+++ b/src/bundler/combine/populateIdentifierReplacements.js
@@ -14,18 +14,22 @@ export default function populateIdentifierReplacements ( bundle ) {
 	// then figure out what identifiers need to be created
 	// for default exports
 	bundle.modules.forEach( mod => {
-		var x;
+		var x = mod.defaultExport;
 
-		if ( x = mod.defaultExport ) {
+		if ( x ) {
+			let result;
+
 			if ( x.hasDeclaration && x.name ) {
-				mod.identifierReplacements.default = hasOwnProp.call( conflicts, x.name ) || otherModulesDeclare( mod, x.name ) ?
-					mod.name + '__' + x.name :
+				result = hasOwnProp.call( conflicts, x.name ) || otherModulesDeclare( mod, x.name ) ?
+					`${mod.name}__${x.name}` :
 					x.name;
 			} else {
-				mod.identifierReplacements.default = hasOwnProp.call( conflicts, mod.name ) || otherModulesDeclare( mod, mod.name ) ?
-					mod.name + '__default' :
+				result = hasOwnProp.call( conflicts, mod.name ) || ( x.value !== mod.name && ~mod.ast._topLevelNames.indexOf( mod.name )) || otherModulesDeclare( mod, mod.name ) ?
+					`${mod.name}__default` :
 					mod.name;
 			}
+
+			mod.identifierReplacements.default = result;
 		}
 	});
 

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -32,15 +32,15 @@ export default function getBundle ( options ) {
 			modules = sortModules( entryModule, moduleLookup ); // TODO is this necessary? surely it's already sorted because of the fetch order? or do we need to prevent parallel reads?
 
 			bundle = {
-				entry: entry,
-				entryModule: entryModule,
-				base: base,
-				modules: modules,
-				moduleLookup: moduleLookup,
-				externalModules: externalModules,
-				externalModuleLookup: externalModuleLookup,
-				skip: skip,
-				names: names,
+				entry,
+				entryModule,
+				base,
+				modules,
+				moduleLookup,
+				externalModules,
+				externalModuleLookup,
+				skip,
+				names,
 				chains: resolveChains( modules, moduleLookup )
 			};
 

--- a/test/bundle/input/38/_config.js
+++ b/test/bundle/input/38/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'Export reassignments are deconflicted'
+};

--- a/test/bundle/input/38/foo.js
+++ b/test/bundle/input/38/foo.js
@@ -1,0 +1,9 @@
+export default notActuallyFoo;
+
+function notActuallyFoo () {
+	foo();
+}
+
+function foo () {
+	console.log( 'actually foo' );
+}

--- a/test/bundle/input/38/main.js
+++ b/test/bundle/input/38/main.js
@@ -1,0 +1,3 @@
+import foo from './foo';
+
+foo();

--- a/test/bundle/output/amd/38.js
+++ b/test/bundle/output/amd/38.js
@@ -1,0 +1,17 @@
+define(function () {
+
+	'use strict';
+
+	var foo__default = notActuallyFoo;
+
+	function notActuallyFoo () {
+		foo();
+	}
+
+	function foo () {
+		console.log( 'actually foo' );
+	}
+
+	foo__default();
+
+});

--- a/test/bundle/output/amdDefaults/38.js
+++ b/test/bundle/output/amdDefaults/38.js
@@ -1,0 +1,17 @@
+define(function () {
+
+	'use strict';
+
+	var foo__default = notActuallyFoo;
+
+	function notActuallyFoo () {
+		foo();
+	}
+
+	function foo () {
+		console.log( 'actually foo' );
+	}
+
+	foo__default();
+
+});

--- a/test/bundle/output/cjs/38.js
+++ b/test/bundle/output/cjs/38.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var foo__default = notActuallyFoo;
+
+function notActuallyFoo () {
+	foo();
+}
+
+function foo () {
+	console.log( 'actually foo' );
+}
+
+foo__default();

--- a/test/bundle/output/cjsDefaults/38.js
+++ b/test/bundle/output/cjsDefaults/38.js
@@ -1,0 +1,13 @@
+'use strict';
+
+var foo__default = notActuallyFoo;
+
+function notActuallyFoo () {
+	foo();
+}
+
+function foo () {
+	console.log( 'actually foo' );
+}
+
+foo__default();

--- a/test/bundle/output/concat/38.js
+++ b/test/bundle/output/concat/38.js
@@ -1,0 +1,15 @@
+(function () { 'use strict';
+
+	var foo__default = notActuallyFoo;
+
+	function notActuallyFoo () {
+		foo();
+	}
+
+	function foo () {
+		console.log( 'actually foo' );
+	}
+
+	foo__default();
+
+})();

--- a/test/bundle/output/umd/38.js
+++ b/test/bundle/output/umd/38.js
@@ -1,0 +1,19 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var foo__default = notActuallyFoo;
+
+	function notActuallyFoo () {
+		foo();
+	}
+
+	function foo () {
+		console.log( 'actually foo' );
+	}
+
+	foo__default();
+
+}));

--- a/test/bundle/output/umdDefaults/38.js
+++ b/test/bundle/output/umdDefaults/38.js
@@ -1,0 +1,19 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var foo__default = notActuallyFoo;
+
+	function notActuallyFoo () {
+		foo();
+	}
+
+	function foo () {
+		console.log( 'actually foo' );
+	}
+
+	foo__default();
+
+}));


### PR DESCRIPTION
Just ran into an awkward case where names would clash:

```js
// foo.js
export default notActuallyFoo;

function notActuallyFoo() {}
function foo() {}
```

This would get `var foo = notActuallyFoo` added to the top of the module within the bundle, which obviously clashes. A neater solution would be to rewrite references to that export in other modules as `notActuallyFoo` rather than having to alias it for their benefit, but that opens a whole nother can of worms that I don't have time for right now.