### PR TITLE
rudimentary profiling

### DIFF
--- a/src/bundler/getModule.js
+++ b/src/bundler/getModule.js
@@ -3,13 +3,16 @@ import MagicString from 'magic-string';
 import findImportsAndExports from 'utils/ast/findImportsAndExports';
 import annotateAst from 'utils/ast/annotate';
 import disallowConflictingImports from '../utils/disallowConflictingImports';
+import { startTimer, endTimer } from '../utils/time';
 
 export default function getModule ( mod ) {
+	mod.stats = {};
 	mod.body = new MagicString( mod.source );
 
 	let toRemove = [];
 
 	try {
+		startTimer();
 		mod.ast = acorn.parse( mod.source, {
 			ecmaVersion: 6,
 			sourceType: 'module',
@@ -20,6 +23,7 @@ export default function getModule ( mod ) {
 				}
 			}
 		});
+		mod.stats.parseTime = endTimer();
 
 		toRemove.forEach( ({ start, end }) => mod.body.remove( start, end ) );
 		annotateAst( mod.ast );

--- a/src/esperanto.js
+++ b/src/esperanto.js
@@ -7,6 +7,7 @@ import moduleBuilders from 'standalone/builders';
 import bundleBuilders from 'bundler/builders';
 import concat from 'bundler/builders/concat';
 import { getName } from 'utils/mappers';
+import { startTimer, endTimer } from './utils/time';
 
 let deprecateMessage = 'options.defaultOnly has been deprecated, and is now standard behaviour. To use named imports/exports, pass `strict: true`.';
 let alreadyWarned = false;
@@ -31,6 +32,8 @@ function transpileMethod ( format ) {
 
 		let builder;
 
+		startTimer( 'build' );
+
 		if ( !options.strict ) {
 			// ensure there are no named imports/exports. TODO link to a wiki page...
 			if ( hasNamedImports( mod ) || hasNamedExports( mod ) ) {
@@ -42,7 +45,9 @@ function transpileMethod ( format ) {
 			builder = moduleBuilders.strictMode[ format ];
 		}
 
-		return builder( mod, options );
+		let transpiled = builder( mod, options );
+		transpiled.stats.build = endTimer( 'build' );
+		return transpiled;
 	};
 }
 
@@ -92,7 +97,11 @@ export default {
 					builder = bundleBuilders.strictMode[ format ];
 				}
 
-				return builder( bundle, options );
+				startTimer( 'build' );
+				let transpiled = builder( bundle, options );
+				transpiled.stats.build = endTimer( 'build' );
+
+				return transpiled;
 			}
 		});
 	}

--- a/src/utils/packageResult.js
+++ b/src/utils/packageResult.js
@@ -1,16 +1,20 @@
 import walk from './ast/walk';
 import { splitPath } from 'utils/sanitize';
+import { startTimer, endTimer } from 'utils/time';
 
 const ABSOLUTE_PATH = /^(?:[A-Z]:)?[\/\\]/i;
 
 let warned = {};
 
 export default function packageResult ( bundleOrModule, body, options, methodName, isBundle ) {
+	startTimer();
+
 	// wrap output
 	if ( options.banner ) body.prepend( options.banner );
 	if ( options.footer ) body.append( options.footer );
 
 	let code = body.toString();
+
 	let map;
 
 	if ( !!options.sourceMap ) {
@@ -51,9 +55,12 @@ export default function packageResult ( bundleOrModule, body, options, methodNam
 		map = null;
 	}
 
+	bundleOrModule.stats.packageResult = endTimer();
+
 	return {
 		code,
 		map,
+		stats: bundleOrModule.stats,
 		toString () {
 			if ( !warned[ methodName ] ) {
 				console.log( `Warning: esperanto.${methodName}() returns an object with a 'code' property. You should use this instead of using the returned value directly` );

--- a/src/utils/time.js
+++ b/src/utils/time.js
@@ -1,0 +1,10 @@
+let startTimes = {};
+
+export function startTimer ( id ) {
+	startTimes[ id || '__' ] = process.hrtime();
+}
+
+export function endTimer ( id ) {
+	let [ seconds, nanoseconds ] = process.hrtime( startTimes[ id || '__' ] );
+	return ( seconds * 1000 ) + ( nanoseconds / 1000000 );
+}

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -8,7 +8,7 @@ global.assert = assert;
 
 module.exports = function () {
 	return new Promise( function ( fulfil ) {
-		var esperanto, start;
+		var esperanto, start, stats = {};
 
 		describe( 'esperanto.bundle()', function () {
 			var profiles;
@@ -32,7 +32,8 @@ module.exports = function () {
 			});
 
 			after( function () {
-				fulfil( Date.now() - start );
+				stats.total = Date.now() - start;
+				fulfil( stats );
 			});
 
 			describe( 'ES6 module semantics tests from es6-module-transpiler:', function () {
@@ -122,6 +123,14 @@ module.exports = function () {
 									amdName: config.amdName,
 									banner: config.banner,
 									footer: config.footer
+								});
+
+								Object.keys( transpiled.stats ).forEach( function ( key ) {
+									if ( !stats[ key ] ) {
+										stats[ key ] = 0;
+									}
+
+									stats[ key ] += transpiled.stats[ key ];
 								});
 
 								if ( config.error ) {

--- a/test/fastMode/index.js
+++ b/test/fastMode/index.js
@@ -9,7 +9,7 @@ module.exports = function () {
 		var esperanto;
 
 		describe( 'fast mode', function () {
-			var tests, start;
+			var tests, start, stats = {};
 
 			this.timeout( 20000 );
 
@@ -49,12 +49,15 @@ module.exports = function () {
 
 				return require( '../utils/build' )().then( function ( lib ) {
 					esperanto = lib;
+
 					start = Date.now();
 				});
 			});
 
 			after( function () {
-				fulfil( Date.now() - start );
+				stats.total = Date.now() - start;
+
+				fulfil( stats );
 			});
 
 			describe( 'esperanto.toAmd()', function () {
@@ -83,6 +86,14 @@ module.exports = function () {
 								absolutePaths: t.config.absolutePaths,
 								banner: t.config.banner,
 								footer: t.config.footer
+							});
+
+							Object.keys( transpiled.stats ).forEach( function ( key ) {
+								if ( !stats[ key ] ) {
+									stats[ key ] = 0;
+								}
+
+								stats[ key ] += transpiled.stats[ key ];
 							});
 						} catch ( err ) {
 							if ( t.config.expectedError && ~err.message.indexOf( t.config.expectedError ) ) {

--- a/test/sourcemaps/index.js
+++ b/test/sourcemaps/index.js
@@ -6,7 +6,7 @@ var Promise = require( 'sander' ).Promise;
 
 module.exports = function () {
 	return new Promise( function ( fulfil ) {
-		var esperanto, start;
+		var esperanto, start, stats = {};
 
 		describe( 'sourcemap', function () {
 			this.timeout( 20000 );
@@ -23,7 +23,8 @@ module.exports = function () {
 			});
 
 			after( function () {
-				fulfil( Date.now() - start );
+				stats.total = Date.now() - start;
+				fulfil( stats );
 			});
 
 			describe( 'standalone', function () {

--- a/test/strictMode/index.js
+++ b/test/strictMode/index.js
@@ -8,7 +8,7 @@ global.assert = assert;
 
 module.exports = function () {
 	return new Promise( function ( fulfil ) {
-		var esperanto, start;
+		var esperanto, start, stats = {};
 
 		describe( 'strict mode', function () {
 			this.timeout( 20000 );
@@ -41,7 +41,8 @@ module.exports = function () {
 			});
 
 			after( function () {
-				fulfil( Date.now() - start );
+				stats.total = Date.now() - start;
+				fulfil( stats );
 			});
 
 			describe( 'esperanto.toAmd()', function () {
@@ -70,6 +71,14 @@ module.exports = function () {
 								banner: t.config.banner,
 								footer: t.config.footer,
 								_evilES3SafeReExports: t.config._evilES3SafeReExports
+							});
+
+							Object.keys( transpiled.stats ).forEach( function ( key ) {
+								if ( !stats[ key ] ) {
+									stats[ key ] = 0;
+								}
+
+								stats[ key ] += transpiled.stats[ key ];
 							});
 						} catch ( err ) {
 							if ( t.config.expectedError && ~err.message.indexOf( t.config.expectedError ) ) {
@@ -113,6 +122,14 @@ module.exports = function () {
 								return sander.readFile( 'es6-module-transpiler-tests/input', dir, file ).then( String ).then( function ( source ) {
 									var transpiled = esperanto.toCjs( source, {
 										strict: true
+									});
+
+									Object.keys( transpiled.stats ).forEach( function ( key ) {
+										if ( !stats[ key ] ) {
+											stats[ key ] = 0;
+										}
+
+										stats[ key ] += transpiled.stats[ key ];
 									});
 
 									return sander.writeFile( 'es6-module-transpiler-tests/output', dir, file, transpiled.code );

--- a/test/test.js
+++ b/test/test.js
@@ -11,8 +11,17 @@ var results = testModules.map( function ( mod ) {
 	return require( './' + mod )();
 });
 
-require( 'sander' ).Promise.all( results ).then( function ( completionTimes ) {
+require( 'sander' ).Promise.all( results ).then( function ( allStats ) {
 	testModules.forEach( function ( mod, i ) {
-		console.log( 'completed %s in %sms', mod, completionTimes[i] );
+		var stats = allStats[i];
+		var keys = Object.keys( stats ).filter( function ( key ) { return key !== 'total'; });
+
+		console.log( '\ncompleted %s in %sms', mod, stats.total );
+
+		if ( keys.length ) {
+			keys.forEach( function ( key ) {
+				console.log( '  %s: %sms', key, stats[ key ].toFixed( 1 ) );
+			});
+		}
 	});
 });


### PR DESCRIPTION
This *probably* isn't for merging, and it's an incomplete WIP, but I thought I'd put it here anyway. I wanted a half-decent way to measure where time is being spent, to see if anything is an obvious performance bottleneck. But it's crude, and the code is a bit crufty.

Anyway, some results from running `npm test`:

```
completed fastMode in 47ms
  parseTime: 6.9ms
  determineImportNames: 1.0ms
  analyse: 11.8ms
  packageResult: 0.1ms
  build: 5.6ms

completed strictMode in 179ms
  parseTime: 22.8ms
  annotateAst: 6.1ms
  determineImportNames: 2.2ms
  analyse: 43.0ms
  packageResult: 0.4ms
  build: 22.1ms

completed bundle in 640ms
  parseTime: 53.7ms
  analyse: 94.9ms
  combine: 76.3ms
  packageResult: 1.2ms
  build: 17.1ms
```

Some of these events are nested (e.g. `parseTime` is wholly contained by `analyse` - there are basically two phases, `analyse` and `build`). Time spend waiting for files to be read is currently ignored.