### PR TITLE
Fix update expressions with exported bindings.

### DIFF
--- a/src/utils/ast/rewriteExportAssignments.js
+++ b/src/utils/ast/rewriteExportAssignments.js
@@ -1,6 +1,6 @@
 import hasOwnProp from 'utils/hasOwnProp';
 
-export default function rewriteExportAssignments ( body, node, exports, scope, capturedUpdates ) {
+export default function rewriteExportAssignments ( body, node, parent, exports, scope, capturedUpdates ) {
 	let assignee;
 
 	if ( node.type === 'AssignmentExpression' ) {
@@ -31,9 +31,19 @@ export default function rewriteExportAssignments ( body, node, exports, scope, c
 
 		// special case - increment/decrement operators
 		if ( node.operator === '++' || node.operator === '--' ) {
-			body.replace( node.end, node.end, `, exports.${exportAs} = ${name}` );
+			let prefix = ``;
+			let suffix = `, exports.${exportAs} = ${name}`;
+			if ( parent.type !== 'ExpressionStatement' ) {
+				if ( !node.prefix ) {
+					suffix += `, ${name} ${node.operator === '++' ? '-' : '+'} 1`
+				}
+				prefix += `( `;
+				suffix += ` )`;
+			}
+			body.insert( node.start, prefix );
+			body.insert( node.end, suffix );
 		} else {
-			body.replace( node.start, node.start, `exports.${exportAs} = ` );
+			body.insert( node.start, `exports.${exportAs} = ` );
 		}
 	}
 }

--- a/src/utils/ast/traverse.js
+++ b/src/utils/ast/traverse.js
@@ -37,7 +37,7 @@ export default function traverseAst ( ast, body, identifierReplacements, importe
 			// Rewrite assignments to exports inside functions, to keep bindings live.
 			// This call may mutate `capturedUpdates`, which is used elsewhere
 			if ( scope !== ast._scope ) {
-				rewriteExportAssignments( body, node, exportNames, scope, capturedUpdates );
+				rewriteExportAssignments( body, node, parent, exportNames, scope, capturedUpdates );
 			}
 
 			if ( node.type === 'Identifier' && parent.type !== 'FunctionExpression' ) {

--- a/test/samples/updateExportInArgument/_config.js
+++ b/test/samples/updateExportInArgument/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'correctly wraps generated sequence expressions',
+	strict: true
+};

--- a/test/samples/updateExportInArgument/source.js
+++ b/test/samples/updateExportInArgument/source.js
@@ -1,0 +1,8 @@
+var a = 100;
+
+function decr () {
+	console.log( '%d bottles of beer on the wall', --a );
+	console.log( '%d bottles of beer', a-- );
+}
+
+export { a as num, decr };

--- a/test/strictMode/output/amd/updateExportInArgument.js
+++ b/test/strictMode/output/amd/updateExportInArgument.js
@@ -1,0 +1,16 @@
+define(['exports'], function (exports) {
+
+	'use strict';
+
+	exports.decr = decr;
+
+	var a = 100;
+
+	function decr () {
+		console.log( '%d bottles of beer on the wall', ( --a, exports.num = a ) );
+		console.log( '%d bottles of beer', ( a--, exports.num = a, a + 1 ) );
+	}
+
+	exports.num = a;
+
+});

--- a/test/strictMode/output/cjs/updateExportInArgument.js
+++ b/test/strictMode/output/cjs/updateExportInArgument.js
@@ -1,0 +1,12 @@
+'use strict';
+
+exports.decr = decr;
+
+var a = 100;
+
+function decr () {
+	console.log( '%d bottles of beer on the wall', ( --a, exports.num = a ) );
+	console.log( '%d bottles of beer', ( a--, exports.num = a, a + 1 ) );
+}
+
+exports.num = a;

--- a/test/strictMode/output/umd/updateExportInArgument.js
+++ b/test/strictMode/output/umd/updateExportInArgument.js
@@ -1,0 +1,18 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
+	typeof define === 'function' && define.amd ? define(['exports'], factory) :
+	factory((global.myModule = {}))
+}(this, function (exports) { 'use strict';
+
+	exports.decr = decr;
+
+	var a = 100;
+
+	function decr () {
+		console.log( '%d bottles of beer on the wall', ( --a, exports.num = a ) );
+		console.log( '%d bottles of beer', ( a--, exports.num = a, a + 1 ) );
+	}
+
+	exports.num = a;
+
+}));


### PR DESCRIPTION
Ideally this would not add parentheses around the sequence expression
if they aren’t needed, but we need access to the parent node to see
whether it’s an ExpressionStatement or not and there does not seem to
be any access.

Closes #137.
Closes #139.