### PR TITLE
preserve .js extension in external modules

### DIFF
--- a/dist/esperanto.browser.js
+++ b/dist/esperanto.browser.js
@@ -1,5 +1,5 @@
 /*
-	esperanto.js v0.6.30 - 2015-04-25
+	esperanto.js v0.6.30 - 2015-04-26
 	http://esperantojs.org
 
 	Released under the MIT License.
@@ -1794,7 +1794,7 @@
 			resolved = importerParts.concat( importParts ).join( '/' );
 		}
 
-		return resolved.replace( /\.js$/, '' );
+		return resolved;
 	}
 
 	function resolveAgainst ( importerPath ) {

--- a/dist/esperanto.js
+++ b/dist/esperanto.js
@@ -1,5 +1,5 @@
 /*
-	esperanto.js v0.6.30 - 2015-04-25
+	esperanto.js v0.6.30 - 2015-04-26
 	http://esperantojs.org
 
 	Released under the MIT License.
@@ -7,10 +7,10 @@
 
 'use strict';
 
-var path = require('path');
-var sander = require('sander');
 var acorn = require('acorn');
 var MagicString = require('magic-string');
+var path = require('path');
+var sander = require('sander');
 
 var hasOwnProp = Object.prototype.hasOwnProperty;
 
@@ -742,7 +742,7 @@ function resolveId ( importPath, importerPath ) {
 		resolved = importerParts.concat( importParts ).join( '/' );
 	}
 
-	return resolved.replace( /\.js$/, '' );
+	return resolved;
 }
 
 function resolveAgainst ( importerPath ) {
@@ -1713,8 +1713,10 @@ function getBundle ( options ) {
 }
 
 function resolvePath ( base, userModules, moduleId, importerPath, resolver ) {
-	return tryPath( base, moduleId + '.js', userModules )
-		.catch( function()  {return tryPath( base, moduleId + path.sep + 'index.js', userModules )} )
+	var noExt = moduleId.replace( /\.js$/, '' );
+
+	return tryPath( base, noExt + '.js', userModules )
+		.catch( function()  {return tryPath( base, noExt + path.sep + 'index.js', userModules )} )
 		.catch( function ( err ) {
 			var resolvedPromise = resolver && getBundle__Promise.resolve( resolver( moduleId, importerPath ) );
 

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -139,8 +139,10 @@ export default function getBundle ( options ) {
 }
 
 function resolvePath ( base, userModules, moduleId, importerPath, resolver ) {
-	return tryPath( base, moduleId + '.js', userModules )
-		.catch( () => tryPath( base, moduleId + path.sep + 'index.js', userModules ) )
+	const noExt = moduleId.replace( /\.js$/, '' );
+
+	return tryPath( base, noExt + '.js', userModules )
+		.catch( () => tryPath( base, noExt + path.sep + 'index.js', userModules ) )
 		.catch( function ( err ) {
 			const resolvedPromise = resolver && Promise.resolve( resolver( moduleId, importerPath ) );
 

--- a/src/utils/resolveId.js
+++ b/src/utils/resolveId.js
@@ -32,7 +32,7 @@ export default function resolveId ( importPath, importerPath ) {
 		resolved = importerParts.concat( importParts ).join( '/' );
 	}
 
-	return resolved.replace( /\.js$/, '' );
+	return resolved;
 }
 
 export function resolveAgainst ( importerPath ) {

--- a/test/bundle/input/51/_config.js
+++ b/test/bundle/input/51/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'leaves trailing .js in external package name',
+	imports: [ 'highlight.js' ]
+};

--- a/test/bundle/input/51/foo.js
+++ b/test/bundle/input/51/foo.js
@@ -1,0 +1,1 @@
+export default 42;

--- a/test/bundle/input/51/main.js
+++ b/test/bundle/input/51/main.js
@@ -1,0 +1,2 @@
+import highlight from 'highlight.js';
+import foo from './foo.js';

--- a/test/bundle/output/amd/51.js
+++ b/test/bundle/output/amd/51.js
@@ -1,0 +1,11 @@
+define(['highlight.js'], function (highlight) {
+
+	'use strict';
+
+	highlight = ('default' in highlight ? highlight['default'] : highlight);
+
+	var foo = 42;
+
+
+
+});

--- a/test/bundle/output/amdDefaults/51.js
+++ b/test/bundle/output/amdDefaults/51.js
@@ -1,0 +1,9 @@
+define(['highlight.js'], function (highlight) {
+
+	'use strict';
+
+	var foo = 42;
+
+
+
+});

--- a/test/bundle/output/cjs/51.js
+++ b/test/bundle/output/cjs/51.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var highlight = require('highlight.js');
+highlight = ('default' in highlight ? highlight['default'] : highlight);
+
+var foo = 42;
+

--- a/test/bundle/output/cjsDefaults/51.js
+++ b/test/bundle/output/cjsDefaults/51.js
@@ -1,0 +1,6 @@
+'use strict';
+
+var highlight = require('highlight.js');
+
+var foo = 42;
+

--- a/test/bundle/output/umd/51.js
+++ b/test/bundle/output/umd/51.js
@@ -1,0 +1,13 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('highlight.js')) :
+	typeof define === 'function' && define.amd ? define(['highlight.js'], factory) :
+	factory(global.highlight)
+}(this, function (highlight) { 'use strict';
+
+	highlight = ('default' in highlight ? highlight['default'] : highlight);
+
+	var foo = 42;
+
+
+
+}));

--- a/test/bundle/output/umdDefaults/51.js
+++ b/test/bundle/output/umdDefaults/51.js
@@ -1,0 +1,11 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('highlight.js')) :
+	typeof define === 'function' && define.amd ? define(['highlight.js'], factory) :
+	factory(global.highlight)
+}(this, function (highlight) { 'use strict';
+
+	var foo = 42;
+
+
+
+}));


### PR DESCRIPTION
Previously, esperanto would always strip `.js` from module import paths, because these...

```js
var foo = require( './foo' );
var foo = require( './foo.js' );
```

...are equivalent in CommonJS-land. (Does the ES6 module spec have an opinion about this? I couldn't find a reference.)

However that's not the case for external modules, which causes problems when creating bundles that import packages like [highlight.js](https://www.npmjs.com/package/highlight.js). This PR keeps the existing behaviour for relative module paths, but preserves the `.js` for external modules. Any opinions to the contrary before I merge it?