### PR TITLE
test case for crazy resolvePath bug

### DIFF
--- a/gobblefile.js
+++ b/gobblefile.js
@@ -14,8 +14,7 @@ banner = require( 'fs' ).readFileSync( __dirname + '/src/banner.js', 'utf-8' )
 node = gobble( 'src' ).transform( 'esperanto-bundle', {
 	entry: 'esperanto',
 	type: 'cjs',
-	banner: banner,
-	sourceMap: false
+	banner: banner
 });
 
 browser = gobble( 'src' ).transform( 'esperanto-bundle', {
@@ -25,7 +24,6 @@ browser = gobble( 'src' ).transform( 'esperanto-bundle', {
 	name: 'esperanto',
 	skip: [ 'bundler/getBundle' ],
 	banner: banner,
-	sourceMap: false,
 
 	// bundle magic-string and its dependency, vlq
 	resolvePath: function ( importee, importer ) {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "gobble-uglifyjs": "^0.1.0",
     "mocha": "^2.1.0",
     "resolve": "^1.1.0",
-    "source-map": "^0.1.40"
+    "source-map": "^0.1.40",
+    "source-map-support": "^0.2.10"
   },
   "files": [
     "esperanto.js",

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -1,4 +1,3 @@
-import path from 'path';
 import MagicString from 'magic-string';
 import populateModuleNames from './populateModuleNames';
 import populateExternalModuleImports from './populateExternalModuleImports';
@@ -41,7 +40,6 @@ export default function combine ( bundle ) {
 		});
 
 		bundle.body.addSource({
-			filename: mod.path,
 			content: transformBody( bundle, mod, mod.body ),
 			indentExclusionRanges: mod.ast._templateLiteralRanges
 		});

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -41,7 +41,7 @@ export default function combine ( bundle ) {
 		});
 
 		bundle.body.addSource({
-			filename: path.resolve( bundle.base, mod.relativePath ),
+			filename: mod.path,
 			content: transformBody( bundle, mod, mod.body ),
 			indentExclusionRanges: mod.ast._templateLiteralRanges
 		});

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -40,6 +40,7 @@ export default function combine ( bundle ) {
 		});
 
 		bundle.body.addSource({
+			filename: mod.path,
 			content: transformBody( bundle, mod, mod.body ),
 			indentExclusionRanges: mod.ast._templateLiteralRanges
 		});

--- a/src/bundler/combine/index.js
+++ b/src/bundler/combine/index.js
@@ -27,15 +27,15 @@ export default function combine ( bundle ) {
 	bundle.modules.forEach( mod => {
 		// verify that this module doesn't import non-exported identifiers
 		mod.imports.forEach( x => {
-			let importedModule = bundle.moduleLookup[ x.id ];
+			const imported = x.module;
 
-			if ( !importedModule || x.isBatch ) {
+			if ( imported.isExternal || imported.isSkipped || x.isBatch ) {
 				return;
 			}
 
 			x.specifiers.forEach( s => {
-				if ( !importedModule.doesExport[ s.name ] ) {
-					throw new Error( `Module '${importedModule.id}' does not export '${s.name}' (imported by '${mod.id}')` );
+				if ( !imported.doesExport[ s.name ] ) {
+					throw new Error( `Module '${imported.id}' does not export '${s.name}' (imported by '${mod.id}')` );
 				}
 			});
 		});

--- a/src/bundler/combine/populateExternalModuleImports.js
+++ b/src/bundler/combine/populateExternalModuleImports.js
@@ -1,9 +1,9 @@
 export default function populateExternalModuleImports ( bundle ) {
 	bundle.modules.forEach( mod => {
 		mod.imports.forEach( x => {
-			var externalModule = bundle.externalModuleLookup[ x.id ];
+			const externalModule = x.module;
 
-			if ( !externalModule ) {
+			if ( !externalModule.isExternal ) {
 				return;
 			}
 

--- a/src/bundler/combine/populateIdentifierReplacements.js
+++ b/src/bundler/combine/populateIdentifierReplacements.js
@@ -52,15 +52,16 @@ export default function populateIdentifierReplacements ( bundle ) {
 			const imported = x.module;
 
 			x.specifiers.forEach( s => {
-				var moduleId, mod, moduleName, specifierName, replacement, hash, isChained, separatorIndex;
-
-				moduleId = imported.id;
+				let replacement;
 
 				if ( s.isBatch ) {
 					replacement = x.module.name;
 				}
 
 				else {
+					let mod;
+					let specifierName;
+
 					if ( s.origin ) {
 						// chained bindings
 						mod = s.origin.module;
@@ -70,7 +71,7 @@ export default function populateIdentifierReplacements ( bundle ) {
 						specifierName = s.name;
 					}
 
-					moduleName = mod && mod.name;
+					const moduleName = mod && mod.name;
 
 					if ( specifierName === 'default' ) {
 						// if it's an external module, always use __default if the

--- a/src/bundler/combine/populateIdentifierReplacements.js
+++ b/src/bundler/combine/populateIdentifierReplacements.js
@@ -61,23 +61,15 @@ export default function populateIdentifierReplacements ( bundle ) {
 				}
 
 				else {
-					specifierName = s.name;
-
-					// If this is a chained import, get the origin
-					hash = `${moduleId}@${specifierName}`;
-					while ( hasOwnProp.call( bundle.chains, hash ) ) {
-						hash = bundle.chains[ hash ];
-						isChained = true;
+					if ( s.origin ) {
+						// chained bindings
+						mod = s.origin.module;
+						specifierName = s.origin.name;
+					} else {
+						mod = imported;
+						specifierName = s.name;
 					}
 
-					if ( isChained ) {
-						separatorIndex = hash.indexOf( '@' );
-						moduleId = hash.substr( 0, separatorIndex );
-						specifierName = hash.substring( separatorIndex + 1 );
-					}
-
-					// TODO handle chains without lookup?
-					mod = ( bundle.moduleLookup[ moduleId ] || bundle.externalModuleLookup[ moduleId ] );
 					moduleName = mod && mod.name;
 
 					if ( specifierName === 'default' ) {
@@ -90,7 +82,7 @@ export default function populateIdentifierReplacements ( bundle ) {
 						// TODO We currently need to check for the existence of `mod`, because modules
 						// can be skipped. Would be better to replace skipped modules with dummies
 						// - see https://github.com/Rich-Harris/esperanto/issues/32
-						else if ( mod ) {
+						else if ( mod && !mod.isSkipped ) {
 							replacement = mod.identifierReplacements.default;
 						}
 					} else if ( !imported.isExternal ) {

--- a/src/bundler/combine/populateModuleNames.js
+++ b/src/bundler/combine/populateModuleNames.js
@@ -26,8 +26,8 @@ export default function getUniqueNames ( bundle ) {
 	// infer names from default imports - e.g. with `import _ from './utils'`,
 	// use '_' instead of generating a name from 'utils'
 	function inferName ( x ) {
-		if ( x.isDefault && !hasOwnProp.call( names, x.id ) && !hasOwnProp.call( used, x.as ) ) {
-			names[ x.id ] = x.as;
+		if ( x.isDefault && !hasOwnProp.call( names, x.module.id ) && !hasOwnProp.call( used, x.as ) ) {
+			names[ x.module.id ] = x.as;
 			used[ x.as ] = true;
 		}
 	}

--- a/src/bundler/combine/resolveExports.js
+++ b/src/bundler/combine/resolveExports.js
@@ -4,29 +4,32 @@ export default function resolveExports ( bundle ) {
 	bundle.entryModule.exports.forEach( x => {
 		if ( x.specifiers ) {
 			x.specifiers.forEach( s => {
-				let hash = `${bundle.entryModule.id}@${s.name}`;
+				let module;
+				let name;
 
-				while ( bundle.chains[ hash ] ) {
-					hash = bundle.chains[ hash ];
+				if ( s.origin ) {
+					module = s.origin.module;
+					name = s.origin.name;
+				} else {
+					module = bundle.entryModule;
+					name = s.name;
 				}
 
-				let [ moduleId, name ] = hash.split( '@' );
-
-				addExport( moduleId, name, s.name );
+				addExport( module, name, s.name );
 			});
 		}
 
 		else if ( !x.isDefault && x.name ) {
-			addExport( bundle.entry, x.name, x.name );
+			addExport( bundle.entryModule, x.name, x.name );
 		}
 	});
 
-	function addExport ( moduleId, name, as ) {
-		if ( !bundleExports[ moduleId ] ) {
-			bundleExports[ moduleId ] = {};
+	function addExport ( module, name, as ) {
+		if ( !bundleExports[ module.id ] ) {
+			bundleExports[ module.id ] = {};
 		}
 
-		bundleExports[ moduleId ][ name ] = as;
+		bundleExports[ module.id ][ name ] = as;
 	}
 
 	return bundleExports;

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -32,7 +32,7 @@ export default function getBundle ( options ) {
 
 	return resolvePath( base, userModules, entry, null ).then( absolutePath => {
 		return fetchModule( entry, absolutePath ).then( entryModule => {
-			modules = sortModules( entryModule, moduleLookup );
+			modules = sortModules( entryModule );
 
 			let bundle = {
 				entryModule,

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -98,16 +98,16 @@ export default function getBundle ( options ) {
 
 				let promises = module.imports.map( x => {
 					// TODO remove this, use x.module instead. more flexible, no lookups involved
-					x.id = resolveId( x.path, module.relativePath );
+					const id = resolveId( x.path, module.relativePath );
 
-					if ( x.id === moduleId ) {
+					if ( id === moduleId ) {
 						throw new Error( 'A module (' + moduleId + ') cannot import itself' );
 					}
 
 					// Some modules can be skipped
-					if ( skip && ~skip.indexOf( x.id ) ) {
+					if ( skip && ~skip.indexOf( id ) ) {
 						const skippedModule = {
-							id: x.id,
+							id,
 							isSkipped: true
 						};
 
@@ -115,13 +115,13 @@ export default function getBundle ( options ) {
 						return skippedModule;
 					}
 
-					return resolvePath( base, userModules, x.id, absolutePath, options.resolvePath ).then( absolutePath => {
+					return resolvePath( base, userModules, id, absolutePath, options.resolvePath ).then( absolutePath => {
 						let promise = hasOwnProp.call( promiseByPath, absolutePath ) && promiseByPath[ absolutePath ];
 						let cyclical = !!promise;
 
 						// short-circuit cycles
 						if ( !cyclical ) {
-							promise = fetchModule( x.id, absolutePath );
+							promise = fetchModule( id, absolutePath );
 						}
 
 						promise.then( module => x.module = module );
@@ -130,16 +130,16 @@ export default function getBundle ( options ) {
 					}, function handleError ( err ) {
 						if ( err.code === 'ENOENT' ) {
 							// Most likely an external module
-							if ( !hasOwnProp.call( externalModuleLookup, x.id ) ) {
+							if ( !hasOwnProp.call( externalModuleLookup, id ) ) {
 								let externalModule = {
-									id: x.id,
+									id,
 									isExternal: true
 								};
 
 								x.module = externalModule;
 
 								externalModules.push( externalModule );
-								externalModuleLookup[ x.id ] = externalModule;
+								externalModuleLookup[ id ] = externalModule;
 							}
 						} else {
 							throw err;

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -36,14 +36,12 @@ export default function getBundle ( options ) {
 			modules = sortModules( entryModule, moduleLookup );
 
 			let bundle = {
-				entry,
+				entry, // TODO don't really need this
 				entryModule,
-				base,
 				modules,
 				moduleLookup,
 				externalModules,
 				externalModuleLookup,
-				skip,
 				names,
 				chains: resolveChains( modules, moduleLookup )
 			};

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -35,14 +35,13 @@ export default function getBundle ( options ) {
 			modules = sortModules( entryModule, moduleLookup );
 
 			let bundle = {
-				entry, // TODO don't really need this
 				entryModule,
 				modules,
 				externalModules,
-				names,
-				chains: resolveChains( modules, moduleLookup )
+				names
 			};
 
+			resolveChains( modules, moduleLookup );
 			combine( bundle );
 
 			return bundle;

--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -38,9 +38,7 @@ export default function getBundle ( options ) {
 				entry, // TODO don't really need this
 				entryModule,
 				modules,
-				moduleLookup,
 				externalModules,
-				externalModuleLookup,
 				names,
 				chains: resolveChains( modules, moduleLookup )
 			};

--- a/src/bundler/utils/resolveChains.js
+++ b/src/bundler/utils/resolveChains.js
@@ -32,5 +32,31 @@ export default function resolveChains ( modules, moduleLookup ) {
 		});
 	});
 
+	// Second pass - assigning origins to specifiers
+	modules.forEach( mod => {
+		mod.imports.forEach( x => {
+			const imported = x.module;
+
+			x.specifiers.forEach( s => {
+				if ( s.isBatch ) {
+					return; // TODO can batch imports be chained?
+				}
+
+				let hash = `${imported.id}@${s.name}`;
+				let isChained;
+
+				while ( hasOwnProp.call( chains, hash ) ) {
+					hash = chains[ hash ];
+					isChained = true;
+				}
+
+				if ( isChained ) {
+					const [ moduleId, name ] = hash.split( '@' );
+					s.origin = { module: moduleLookup[ moduleId ], name };
+				}
+			});
+		});
+	});
+
 	return chains;
 }

--- a/src/bundler/utils/resolveChains.js
+++ b/src/bundler/utils/resolveChains.js
@@ -8,18 +8,16 @@ export default function resolveChains ( modules, moduleLookup ) {
 		var origin = {};
 
 		mod.imports.forEach( x => {
+			const imported = x.module;
+
 			x.specifiers.forEach( s => {
 				if ( s.isBatch ) {
-					// if this is an internal module, we need to tell that module that
-					// it needs to export an object full of getters
-					if ( hasOwnProp.call( moduleLookup, x.id ) ) {
-						moduleLookup[ x.id ]._exportsNamespace = true;
-					}
-
+					// tell that module that it needs to export an object full of getters
+					imported._exportsNamespace = true;
 					return; // TODO can batch imports be chained?
 				}
 
-				origin[ s.as ] = `${x.id}@${s.name}`;
+				origin[ s.as ] = `${imported.id}@${s.name}`;
 			});
 		});
 

--- a/src/bundler/utils/resolveChains.js
+++ b/src/bundler/utils/resolveChains.js
@@ -56,7 +56,24 @@ export default function resolveChains ( modules, moduleLookup ) {
 				}
 			});
 		});
-	});
 
-	return chains;
+		mod.exports.forEach( x => {
+			if ( !x.specifiers ) return;
+
+			x.specifiers.forEach( s => {
+				let hash = `${mod.id}@${s.name}`;
+				let isChained;
+
+				while ( hasOwnProp.call( chains, hash ) ) {
+					hash = chains[ hash ];
+					isChained = true;
+				}
+
+				if ( isChained ) {
+					const [ moduleId, name ] = hash.split( '@' );
+					s.origin = { module: moduleLookup[ moduleId ], name };
+				}
+			});
+		});
+	});
 }

--- a/src/bundler/utils/resolveChains.js
+++ b/src/bundler/utils/resolveChains.js
@@ -17,7 +17,7 @@ export default function resolveChains ( modules, moduleLookup ) {
 					return; // TODO can batch imports be chained?
 				}
 
-				origin[ s.as ] = `${imported.id}@${s.name}`;
+				origin[ s.as ] = `${s.name}@${imported.id}`;
 			});
 		});
 
@@ -26,7 +26,7 @@ export default function resolveChains ( modules, moduleLookup ) {
 
 			x.specifiers.forEach( s => {
 				if ( hasOwnProp.call( origin, s.name ) ) {
-					chains[ `${mod.id}@${s.name}` ] = origin[ s.name ];
+					chains[ `${s.name}@${mod.id}` ] = origin[ s.name ];
 				}
 			});
 		});
@@ -42,18 +42,7 @@ export default function resolveChains ( modules, moduleLookup ) {
 					return; // TODO can batch imports be chained?
 				}
 
-				let hash = `${imported.id}@${s.name}`;
-				let isChained;
-
-				while ( hasOwnProp.call( chains, hash ) ) {
-					hash = chains[ hash ];
-					isChained = true;
-				}
-
-				if ( isChained ) {
-					const [ moduleId, name ] = hash.split( '@' );
-					s.origin = { module: moduleLookup[ moduleId ], name };
-				}
+				setOrigin( s, `${s.name}@${imported.id}`, chains, moduleLookup );
 			});
 		});
 
@@ -61,19 +50,22 @@ export default function resolveChains ( modules, moduleLookup ) {
 			if ( !x.specifiers ) return;
 
 			x.specifiers.forEach( s => {
-				let hash = `${mod.id}@${s.name}`;
-				let isChained;
-
-				while ( hasOwnProp.call( chains, hash ) ) {
-					hash = chains[ hash ];
-					isChained = true;
-				}
-
-				if ( isChained ) {
-					const [ moduleId, name ] = hash.split( '@' );
-					s.origin = { module: moduleLookup[ moduleId ], name };
-				}
+				setOrigin( s, `${s.name}@${mod.id}`, chains, moduleLookup );
 			});
 		});
 	});
+}
+
+function setOrigin ( specifier, hash, chains, moduleLookup ) {
+	let isChained;
+
+	while ( hasOwnProp.call( chains, hash ) ) {
+		hash = chains[ hash ];
+		isChained = true;
+	}
+
+	if ( isChained ) {
+		const [ name, moduleId ] = hash.split( '@' );
+		specifier.origin = { module: moduleLookup[ moduleId ], name };
+	}
 }

--- a/src/bundler/utils/sortModules.js
+++ b/src/bundler/utils/sortModules.js
@@ -1,7 +1,7 @@
 import hasOwnProp from 'utils/hasOwnProp';
 import walk from 'utils/ast/walk';
 
-export default function sortModules ( entry, moduleLookup ) {
+export default function sortModules ( entry ) {
 	let seen = {};
 	let ordered = [];
 	let swapPairs = [];

--- a/src/bundler/utils/sortModules.js
+++ b/src/bundler/utils/sortModules.js
@@ -10,9 +10,9 @@ export default function sortModules ( entry, moduleLookup ) {
 		seen[ mod.id ] = true;
 
 		mod.imports.forEach( x => {
-			const imported = moduleLookup[ x.id ];
+			const imported = x.module;
 
-			if ( !imported ) return;
+			if ( imported.isExternal || imported.isSkipped ) return;
 
 			// ignore modules we've already included
 			if ( hasOwnProp.call( seen, imported.id ) ) {
@@ -52,7 +52,7 @@ function shouldSwap ( a, b ) {
 function imports ( a, b ) {
 	let i = a.imports.length;
 	while ( i-- ) {
-		if ( a.imports[i].id === b.id ) {
+		if ( a.imports[i].module === b ) {
 			return true;
 		}
 	}
@@ -64,7 +64,7 @@ function usesAtTopLevel ( a, b ) {
 	// find out which bindings a imports from b
 	let i = a.imports.length;
 	while ( i-- ) {
-		if ( a.imports[i].id === b.id ) {
+		if ( a.imports[i].module === b ) {
 			bindings.push.apply( bindings, a.imports[i].specifiers.map( x => x.as ) );
 		}
 	}

--- a/src/esperanto.js
+++ b/src/esperanto.js
@@ -1,4 +1,3 @@
-import hasOwnProp from 'utils/hasOwnProp';
 import hasNamedImports from 'utils/hasNamedImports';
 import hasNamedExports from 'utils/hasNamedExports';
 import getStandaloneModule from 'standalone/getModule';

--- a/src/esperanto.js
+++ b/src/esperanto.js
@@ -81,7 +81,7 @@ export default {
 
 					bundle.modules.forEach( mod => {
 						mod.imports.forEach( x => {
-							if ( hasOwnProp.call( bundle.externalModuleLookup, x.id ) && ( !x.isDefault && !x.isBatch ) ) {
+							if ( x.module.isExternal && ( !x.isDefault && !x.isBatch ) ) {
 								throw new Error( 'You can only have named external imports in strict mode (pass `strict: true`)' );
 							}
 						});

--- a/src/utils/ast/findImportsAndExports.js
+++ b/src/utils/ast/findImportsAndExports.js
@@ -70,7 +70,7 @@ export default function findImportsAndExports ( mod, source, ast ) {
  */
 function processImport ( node, passthrough ) {
 	var x = {
-		id: null, // used by bundler - filled in later
+		module: null, // used by bundler - filled in later
 		node: node,
 		start: node.start,
 		end: node.end,

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -112,7 +112,7 @@ module.exports = function () {
 									options = profile.options || {};
 
 									if ( ( bundle.imports.length && !config.imports ) || ( bundle.exports.length && !config.exports ) ) {
-										throw new Error( 'config is missing imports/exports' );
+										throw new Error( 'config is missing imports/exports (expected ' + JSON.stringify( bundle.imports ) + ', ' + JSON.stringify( bundle.exports ) + ')' );
 									}
 
 									if ( config.imports || bundle.imports.length ) {

--- a/test/bundle/input/52/_config.js
+++ b/test/bundle/input/52/_config.js
@@ -1,0 +1,8 @@
+var path = require( 'path' );
+
+module.exports = {
+	description: 'allows imported bindings to share names with builtins',
+	resolvePath: function ( importee ) {
+		return path.resolve( __dirname, 'external', importee.slice( 4 ) ) + '.js';
+	}
+};

--- a/test/bundle/input/52/_config.js
+++ b/test/bundle/input/52/_config.js
@@ -1,7 +1,7 @@
 var path = require( 'path' );
 
 module.exports = {
-	description: 'allows imported bindings to share names with builtins',
+	description: 'correctly renames bindings from modules referred to by local and external-ish modules',
 	resolvePath: function ( importee ) {
 		return path.resolve( __dirname, 'external', importee.slice( 4 ) ) + '.js';
 	}

--- a/test/bundle/input/52/bar.js
+++ b/test/bundle/input/52/bar.js
@@ -1,0 +1,4 @@
+import baz from 'ext/baz';
+
+// bar.js
+console.log( 'baz', baz );

--- a/test/bundle/input/52/external/baz.js
+++ b/test/bundle/input/52/external/baz.js
@@ -1,0 +1,3 @@
+export default function () {
+	// baz.js
+};

--- a/test/bundle/input/52/external/foo.js
+++ b/test/bundle/input/52/external/foo.js
@@ -1,0 +1,3 @@
+import not_baz from './baz';
+
+// foo.js

--- a/test/bundle/input/52/main.js
+++ b/test/bundle/input/52/main.js
@@ -1,0 +1,4 @@
+import 'ext/foo';
+import './bar';
+
+// main.js

--- a/test/bundle/output/amd/52.js
+++ b/test/bundle/output/amd/52.js
@@ -1,0 +1,15 @@
+define(function () {
+
+	'use strict';
+
+	var not_baz = function () {
+		// baz.js
+	};
+
+
+
+	console.log( 'baz', not_baz );
+
+
+
+});

--- a/test/bundle/output/amdDefaults/52.js
+++ b/test/bundle/output/amdDefaults/52.js
@@ -1,0 +1,15 @@
+define(function () {
+
+	'use strict';
+
+	var not_baz = function () {
+		// baz.js
+	};
+
+
+
+	console.log( 'baz', not_baz );
+
+
+
+});

--- a/test/bundle/output/cjs/52.js
+++ b/test/bundle/output/cjs/52.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var not_baz = function () {
+	// baz.js
+};
+
+
+
+console.log( 'baz', not_baz );
+

--- a/test/bundle/output/cjsDefaults/52.js
+++ b/test/bundle/output/cjsDefaults/52.js
@@ -1,0 +1,10 @@
+'use strict';
+
+var not_baz = function () {
+	// baz.js
+};
+
+
+
+console.log( 'baz', not_baz );
+

--- a/test/bundle/output/concat/52.js
+++ b/test/bundle/output/concat/52.js
@@ -1,0 +1,13 @@
+(function () { 'use strict';
+
+	var not_baz = function () {
+		// baz.js
+	};
+
+
+
+	console.log( 'baz', not_baz );
+
+
+
+})();

--- a/test/bundle/output/umd/52.js
+++ b/test/bundle/output/umd/52.js
@@ -1,0 +1,17 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var not_baz = function () {
+		// baz.js
+	};
+
+
+
+	console.log( 'baz', not_baz );
+
+
+
+}));

--- a/test/bundle/output/umdDefaults/52.js
+++ b/test/bundle/output/umdDefaults/52.js
@@ -1,0 +1,17 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var not_baz = function () {
+		// baz.js
+	};
+
+
+
+	console.log( 'baz', not_baz );
+
+
+
+}));

--- a/test/test.js
+++ b/test/test.js
@@ -1,3 +1,5 @@
+require( 'source-map-support' ).install();
+
 process.chdir( __dirname );
 
 var testModules = [

--- a/test/test.js
+++ b/test/test.js
@@ -3,10 +3,10 @@ require( 'source-map-support' ).install();
 process.chdir( __dirname );
 
 var testModules = [
-	// 'fastMode',
-	// 'strictMode',
+	'fastMode',
+	'strictMode',
 	'bundle',
-	// 'sourcemaps'
+	'sourcemaps'
 ];
 
 var results = testModules.map( function ( mod ) {

--- a/test/test.js
+++ b/test/test.js
@@ -1,10 +1,10 @@
 process.chdir( __dirname );
 
 var testModules = [
-	'fastMode',
-	'strictMode',
+	// 'fastMode',
+	// 'strictMode',
 	'bundle',
-	'sourcemaps'
+	// 'sourcemaps'
 ];
 
 var results = testModules.map( function ( mod ) {


### PR DESCRIPTION
No fix yet, but a test case for a very niche bug I've encountered. I *think* what's happening is that the same module is identified two different ways if it's imported by a module that's relative to `base` versus a module with an absolute path...