### PR TITLE
Better sorting algorithm for cyclical dependencies (#159)

### DIFF
--- a/src/bundler/utils/sortModules.js
+++ b/src/bundler/utils/sortModules.js
@@ -17,7 +17,7 @@ export default function sortModules ( entry ) {
 		strongDeps[ id ] = [];
 		stronglyDependsOn[ id ] = {};
 
-		mod.imports.forEach( ( x, i ) => {
+		mod.imports.forEach( x => {
 			const imported = x.module;
 
 			if ( imported.isExternal || imported.isSkipped ) return;
@@ -100,16 +100,13 @@ function referencesAtTopLevel ( a, b ) {
 
 	walk( a.ast, {
 		enter ( node ) {
-			if ( referencedAtTopLevel ) {
-				return this.skip();
-			}
-
 			if ( /^Import/.test( node.type ) || ( node._scope && node._scope.parent ) ) {
 				return this.skip();
 			}
 
 			if ( node.type === 'Identifier' && ~bindings.indexOf( node.name ) ) {
 				referencedAtTopLevel = true;
+				this.abort();
 			}
 		}
 	});

--- a/src/utils/ast/walk.js
+++ b/src/utils/ast/walk.js
@@ -1,9 +1,14 @@
+let shouldSkip;
+let shouldAbort;
+
 export default function walk ( ast, { enter, leave }) {
+	shouldAbort = false;
 	visit( ast, null, enter, leave );
 }
 
 let context = {
-	skip: () => context.shouldSkip = true
+	skip: () => shouldSkip = true,
+	abort: () => shouldAbort = true
 };
 
 let childKeys = {};
@@ -15,12 +20,12 @@ function isArray ( thing ) {
 }
 
 function visit ( node, parent, enter, leave ) {
-	if ( !node ) return;
+	if ( !node || shouldAbort ) return;
 
 	if ( enter ) {
-		context.shouldSkip = false;
+		shouldSkip = false;
 		enter.call( context, node, parent );
-		if ( context.shouldSkip ) return;
+		if ( shouldSkip || shouldAbort ) return;
 	}
 
 	let keys = childKeys[ node.type ] || (
@@ -46,7 +51,7 @@ function visit ( node, parent, enter, leave ) {
 		}
 	}
 
-	if ( leave ) {
+	if ( leave && !shouldAbort ) {
 		leave( node, parent );
 	}
 }

--- a/test/bundle/input/50/_config.js
+++ b/test/bundle/input/50/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	description: 'cyclical dependency order is resolved based on need (#152)'
+	description: 'cyclical dependency order is resolved based on need (#152)',
+	//solo: true
 };

--- a/test/bundle/input/55/A.js
+++ b/test/bundle/input/55/A.js
@@ -1,0 +1,14 @@
+import B from './B';
+import C from './C';
+
+class A {
+	b () {
+		return new B();
+	}
+
+	c () {
+		return new C();
+	}
+}
+
+export default A;

--- a/test/bundle/input/55/B.js
+++ b/test/bundle/input/55/B.js
@@ -1,0 +1,5 @@
+import A from './A';
+
+class B extends A {}
+
+export default B;

--- a/test/bundle/input/55/C.js
+++ b/test/bundle/input/55/C.js
@@ -1,0 +1,5 @@
+import A from './A';
+
+class C extends A {}
+
+export default C;

--- a/test/bundle/input/55/_config.js
+++ b/test/bundle/input/55/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'handles more complex mutually dependent module scenario (#157)',
+	//solo: true
+};

--- a/test/bundle/input/55/_config.js
+++ b/test/bundle/input/55/_config.js
@@ -1,4 +1,3 @@
 module.exports = {
-	description: 'handles more complex mutually dependent module scenario (#157)',
-	//solo: true
+	description: 'handles more complex mutually dependent module scenario (#157)'
 };

--- a/test/bundle/input/55/main.js
+++ b/test/bundle/input/55/main.js
@@ -1,0 +1,1 @@
+import A from './A';

--- a/test/bundle/output/amd/55.js
+++ b/test/bundle/output/amd/55.js
@@ -1,0 +1,27 @@
+define(function () {
+
+	'use strict';
+
+	class A {
+		b () {
+			return new _B();
+		}
+
+		c () {
+			return new _C();
+		}
+	}
+
+	var _A = A;
+
+	class B extends _A {}
+
+	var _B = B;
+
+	class C extends _A {}
+
+	var _C = C;
+
+
+
+});

--- a/test/bundle/output/amdDefaults/55.js
+++ b/test/bundle/output/amdDefaults/55.js
@@ -1,0 +1,27 @@
+define(function () {
+
+	'use strict';
+
+	class A {
+		b () {
+			return new _B();
+		}
+
+		c () {
+			return new _C();
+		}
+	}
+
+	var _A = A;
+
+	class B extends _A {}
+
+	var _B = B;
+
+	class C extends _A {}
+
+	var _C = C;
+
+
+
+});

--- a/test/bundle/output/cjs/55.js
+++ b/test/bundle/output/cjs/55.js
@@ -1,0 +1,22 @@
+'use strict';
+
+class A {
+	b () {
+		return new _B();
+	}
+
+	c () {
+		return new _C();
+	}
+}
+
+var _A = A;
+
+class B extends _A {}
+
+var _B = B;
+
+class C extends _A {}
+
+var _C = C;
+

--- a/test/bundle/output/cjsDefaults/55.js
+++ b/test/bundle/output/cjsDefaults/55.js
@@ -1,0 +1,22 @@
+'use strict';
+
+class A {
+	b () {
+		return new _B();
+	}
+
+	c () {
+		return new _C();
+	}
+}
+
+var _A = A;
+
+class B extends _A {}
+
+var _B = B;
+
+class C extends _A {}
+
+var _C = C;
+

--- a/test/bundle/output/concat/55.js
+++ b/test/bundle/output/concat/55.js
@@ -1,0 +1,25 @@
+(function () { 'use strict';
+
+	class A {
+		b () {
+			return new _B();
+		}
+
+		c () {
+			return new _C();
+		}
+	}
+
+	var _A = A;
+
+	class B extends _A {}
+
+	var _B = B;
+
+	class C extends _A {}
+
+	var _C = C;
+
+
+
+})();

--- a/test/bundle/output/umd/55.js
+++ b/test/bundle/output/umd/55.js
@@ -1,0 +1,29 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	class A {
+		b () {
+			return new _B();
+		}
+
+		c () {
+			return new _C();
+		}
+	}
+
+	var _A = A;
+
+	class B extends _A {}
+
+	var _B = B;
+
+	class C extends _A {}
+
+	var _C = C;
+
+
+
+}));

--- a/test/bundle/output/umdDefaults/55.js
+++ b/test/bundle/output/umdDefaults/55.js
@@ -1,0 +1,29 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	class A {
+		b () {
+			return new _B();
+		}
+
+		c () {
+			return new _C();
+		}
+	}
+
+	var _A = A;
+
+	class B extends _A {}
+
+	var _B = B;
+
+	class C extends _A {}
+
+	var _C = C;
+
+
+
+}));


### PR DESCRIPTION
See #159. This algorithm has been tested with some pretty gnarly cyclical dependencies and seems to hold up. Would welcome any input though if it looks wonky.

Will try and explain what's going on:

* We start with a topological sort, as before, but before visiting module `b` imported from module `a`, we check to see if `a` *strongly* depends on `b`, or only *weakly*. If strongly, we make a note of it (in the code, this is `strongDeps[a.id].push(b)`)
* If we find ourselves about to visit an 'undead' node (i.e. one that we're already in the process of visiting), we know that we have a cyclical dependency - e.g. `b` imports `a`. This means that our module order *may* be incorrect. We check first to see if `b` strongly depends on `a`.
* After visiting each of a module's imports (and hence all of their imports), we can make a note of all its second- and third-order (etc) strong dependencies (in the code, `stronglyDependsOn[a.id][b.id] = true`), before pushing it to our list of modules.
* If we didn't encounter any cylical dependencies, the module order is already correct.
* Otherwise, we create a new `ordered` list, and iterate over the old one. For each module in the original list, we place *all* of its strong dependencies *before* the module itself - this has the effect of placing `a` before `b` if `b` strongly depends on `a` and `a` only weakly depends on `b`, regardless of their original order.