### PR TITLE
don't rename default exports unnecessarily

### DIFF
--- a/src/bundler/combine/populateModuleNames.js
+++ b/src/bundler/combine/populateModuleNames.js
@@ -8,7 +8,19 @@ export default function getUniqueNames ( bundle ) {
 	let names = {};
 
 	let used = modules.reduce( ( declared, mod ) => {
-		Object.keys( mod.ast._declared ).forEach( x => declared[x] = true );
+		const defaultExport = mod.defaultExport;
+		const defaultExportName = defaultExport &&
+		                          !defaultExport.unsafe &&
+		                          defaultExport.type === 'expression' &&
+		                          defaultExport.node.declaration &&
+		                          defaultExport.node.declaration.type === 'Identifier' &&
+		                          defaultExport.node.declaration.name;
+
+		Object.keys( mod.ast._declared ).forEach( x => {
+			// special case - `export default foo`
+			if ( x === defaultExportName ) return;
+			declared[x] = true;
+		});
 		return declared;
 	}, {} );
 

--- a/src/standalone/getModule.js
+++ b/src/standalone/getModule.js
@@ -37,17 +37,20 @@ export default function getStandaloneModule ( options ) {
 
 	toRemove.forEach( ({ start, end }) => mod.body.remove( start, end ) );
 
-	let [ imports, exports ] = findImportsAndExports( mod, code, mod.ast );
+	let { imports, exports, defaultExport } = findImportsAndExports( mod.ast, code );
 
 	disallowConflictingImports( imports );
 
 	mod.imports = imports;
 	mod.exports = exports;
+	mod.defaultExport = defaultExport;
 
 	let conflicts = {};
 
 	if ( options.strict ) {
-		annotateAst( mod.ast );
+		annotateAst( mod.ast, {
+			trackAssignments: null
+		});
 
 		// TODO there's probably an easier way to get this array
 		Object.keys( mod.ast._declared ).concat( getUnscopedNames( mod ) ).forEach( n => {

--- a/src/utils/ast/findImportsAndExports.js
+++ b/src/utils/ast/findImportsAndExports.js
@@ -1,12 +1,14 @@
 /**
  * Inspects a module and discovers/categorises import & export declarations
- * @param {object} mod - the module object
- * @param {string} source - the module's original source code
  * @param {object} ast - the result of parsing `source` with acorn
- * @returns {array} - [ imports, exports ]
+ * @param {string} source - the module's original source code
+ * @returns {object} - { imports, exports, defaultExport }
  */
-export default function findImportsAndExports ( mod, source, ast ) {
-	var imports = [], exports = [], previousDeclaration;
+export default function findImportsAndExports ( ast, source ) {
+	let imports = [];
+	let exports = [];
+	let defaultExport;
+	let previousDeclaration;
 
 	ast.body.forEach( node => {
 		var passthrough, declaration;
@@ -28,10 +30,10 @@ export default function findImportsAndExports ( mod, source, ast ) {
 			declaration = processDefaultExport( node, source );
 			exports.push( declaration );
 
-			if ( mod.defaultExport ) {
+			if ( defaultExport ) {
 				throw new Error( 'Duplicate default exports' );
 			}
-			mod.defaultExport = declaration;
+			defaultExport = declaration;
 		}
 
 		else if ( node.type === 'ExportNamedDeclaration' ) {
@@ -59,7 +61,7 @@ export default function findImportsAndExports ( mod, source, ast ) {
 		previousDeclaration.isFinal = true;
 	}
 
-	return [ imports, exports ];
+	return { imports, exports, defaultExport };
 }
 
 /**

--- a/test/bundle/input/56/_config.js
+++ b/test/bundle/input/56/_config.js
@@ -1,0 +1,4 @@
+module.exports = {
+	description: 'default exports are not live',
+	//solo: true
+};

--- a/test/bundle/input/56/foo.js
+++ b/test/bundle/input/56/foo.js
@@ -1,0 +1,5 @@
+var foo = 42;
+export default foo;
+foo = 99;
+foo += 1;
+foo++;

--- a/test/bundle/input/56/main.js
+++ b/test/bundle/input/56/main.js
@@ -1,0 +1,3 @@
+import foo from './foo';
+
+console.log( foo ); // 42

--- a/test/bundle/output/amd/19.js
+++ b/test/bundle/output/amd/19.js
@@ -3,8 +3,7 @@ define(function () {
 	'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
-	var _hasOwnProperty = hasOwnProperty;
 
-	console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 
 });

--- a/test/bundle/output/amd/37.js
+++ b/test/bundle/output/amd/37.js
@@ -1,11 +1,11 @@
-define(['moment'], function (moment) {
+define(['moment'], function (x) {
 
 	'use strict';
 
-	moment = ('default' in moment ? moment['default'] : moment);
+	x = ('default' in x ? x['default'] : x);
 
-	var x = 'wut';
-	var a = x;
+	var a__x = 'wut';
+	var a = a__x;
 
 
 

--- a/test/bundle/output/amd/55.js
+++ b/test/bundle/output/amd/55.js
@@ -4,23 +4,17 @@ define(function () {
 
 	class A {
 		b () {
-			return new _B();
+			return new B();
 		}
 
 		c () {
-			return new _C();
+			return new C();
 		}
 	}
 
-	var _A = A;
+	class B extends A {}
 
-	class B extends _A {}
-
-	var _B = B;
-
-	class C extends _A {}
-
-	var _C = C;
+	class C extends A {}
 
 
 

--- a/test/bundle/output/amd/56.js
+++ b/test/bundle/output/amd/56.js
@@ -1,0 +1,13 @@
+define(function () {
+
+	'use strict';
+
+	var foo = 42;
+	var _foo = foo;
+	foo = 99;
+	foo += 1;
+	foo++;
+
+	console.log( _foo ); // 42
+
+});

--- a/test/bundle/output/amdDefaults/19.js
+++ b/test/bundle/output/amdDefaults/19.js
@@ -3,8 +3,7 @@ define(function () {
 	'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
-	var _hasOwnProperty = hasOwnProperty;
 
-	console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 
 });

--- a/test/bundle/output/amdDefaults/37.js
+++ b/test/bundle/output/amdDefaults/37.js
@@ -1,9 +1,9 @@
-define(['moment'], function (moment) {
+define(['moment'], function (x) {
 
 	'use strict';
 
-	var x = 'wut';
-	var a = x;
+	var a__x = 'wut';
+	var a = a__x;
 
 
 

--- a/test/bundle/output/amdDefaults/55.js
+++ b/test/bundle/output/amdDefaults/55.js
@@ -4,23 +4,17 @@ define(function () {
 
 	class A {
 		b () {
-			return new _B();
+			return new B();
 		}
 
 		c () {
-			return new _C();
+			return new C();
 		}
 	}
 
-	var _A = A;
+	class B extends A {}
 
-	class B extends _A {}
-
-	var _B = B;
-
-	class C extends _A {}
-
-	var _C = C;
+	class C extends A {}
 
 
 

--- a/test/bundle/output/amdDefaults/56.js
+++ b/test/bundle/output/amdDefaults/56.js
@@ -1,0 +1,13 @@
+define(function () {
+
+	'use strict';
+
+	var foo = 42;
+	var _foo = foo;
+	foo = 99;
+	foo += 1;
+	foo++;
+
+	console.log( _foo ); // 42
+
+});

--- a/test/bundle/output/cjs/19.js
+++ b/test/bundle/output/cjs/19.js
@@ -1,6 +1,5 @@
 'use strict';
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
-var _hasOwnProperty = hasOwnProperty;
 
-console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );

--- a/test/bundle/output/cjs/37.js
+++ b/test/bundle/output/cjs/37.js
@@ -1,8 +1,8 @@
 'use strict';
 
-var moment = require('moment');
-moment = ('default' in moment ? moment['default'] : moment);
+var x = require('moment');
+x = ('default' in x ? x['default'] : x);
 
-var x = 'wut';
-var a = x;
+var a__x = 'wut';
+var a = a__x;
 

--- a/test/bundle/output/cjs/55.js
+++ b/test/bundle/output/cjs/55.js
@@ -2,21 +2,15 @@
 
 class A {
 	b () {
-		return new _B();
+		return new B();
 	}
 
 	c () {
-		return new _C();
+		return new C();
 	}
 }
 
-var _A = A;
+class B extends A {}
 
-class B extends _A {}
-
-var _B = B;
-
-class C extends _A {}
-
-var _C = C;
+class C extends A {}
 

--- a/test/bundle/output/cjs/56.js
+++ b/test/bundle/output/cjs/56.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = 42;
+var _foo = foo;
+foo = 99;
+foo += 1;
+foo++;
+
+console.log( _foo ); // 42

--- a/test/bundle/output/cjsDefaults/19.js
+++ b/test/bundle/output/cjsDefaults/19.js
@@ -1,6 +1,5 @@
 'use strict';
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
-var _hasOwnProperty = hasOwnProperty;
 
-console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );

--- a/test/bundle/output/cjsDefaults/37.js
+++ b/test/bundle/output/cjsDefaults/37.js
@@ -1,7 +1,7 @@
 'use strict';
 
-var moment = require('moment');
+var x = require('moment');
 
-var x = 'wut';
-var a = x;
+var a__x = 'wut';
+var a = a__x;
 

--- a/test/bundle/output/cjsDefaults/55.js
+++ b/test/bundle/output/cjsDefaults/55.js
@@ -2,21 +2,15 @@
 
 class A {
 	b () {
-		return new _B();
+		return new B();
 	}
 
 	c () {
-		return new _C();
+		return new C();
 	}
 }
 
-var _A = A;
+class B extends A {}
 
-class B extends _A {}
-
-var _B = B;
-
-class C extends _A {}
-
-var _C = C;
+class C extends A {}
 

--- a/test/bundle/output/cjsDefaults/56.js
+++ b/test/bundle/output/cjsDefaults/56.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = 42;
+var _foo = foo;
+foo = 99;
+foo += 1;
+foo++;
+
+console.log( _foo ); // 42

--- a/test/bundle/output/concat/19.js
+++ b/test/bundle/output/concat/19.js
@@ -1,8 +1,7 @@
 (function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
-	var _hasOwnProperty = hasOwnProperty;
 
-	console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 
 })();

--- a/test/bundle/output/concat/55.js
+++ b/test/bundle/output/concat/55.js
@@ -2,23 +2,17 @@
 
 	class A {
 		b () {
-			return new _B();
+			return new B();
 		}
 
 		c () {
-			return new _C();
+			return new C();
 		}
 	}
 
-	var _A = A;
+	class B extends A {}
 
-	class B extends _A {}
-
-	var _B = B;
-
-	class C extends _A {}
-
-	var _C = C;
+	class C extends A {}
 
 
 

--- a/test/bundle/output/concat/56.js
+++ b/test/bundle/output/concat/56.js
@@ -1,0 +1,11 @@
+(function () { 'use strict';
+
+	var foo = 42;
+	var _foo = foo;
+	foo = 99;
+	foo += 1;
+	foo++;
+
+	console.log( _foo ); // 42
+
+})();

--- a/test/bundle/output/umd/37.js
+++ b/test/bundle/output/umd/37.js
@@ -1,13 +1,13 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.moment)
-}(this, function (moment) { 'use strict';
+	factory(global.x)
+}(this, function (x) { 'use strict';
 
-	moment = ('default' in moment ? moment['default'] : moment);
+	x = ('default' in x ? x['default'] : x);
 
-	var x = 'wut';
-	var a = x;
+	var a__x = 'wut';
+	var a = a__x;
 
 
 

--- a/test/bundle/output/umd/55.js
+++ b/test/bundle/output/umd/55.js
@@ -6,23 +6,17 @@
 
 	class A {
 		b () {
-			return new _B();
+			return new B();
 		}
 
 		c () {
-			return new _C();
+			return new C();
 		}
 	}
 
-	var _A = A;
+	class B extends A {}
 
-	class B extends _A {}
-
-	var _B = B;
-
-	class C extends _A {}
-
-	var _C = C;
+	class C extends A {}
 
 
 

--- a/test/bundle/output/umd/56.js
+++ b/test/bundle/output/umd/56.js
@@ -4,8 +4,12 @@
 	factory()
 }(function () { 'use strict';
 
-	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var foo = 42;
+	var _foo = foo;
+	foo = 99;
+	foo += 1;
+	foo++;
 
-	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( _foo ); // 42
 
 }));

--- a/test/bundle/output/umdDefaults/19.js
+++ b/test/bundle/output/umdDefaults/19.js
@@ -5,8 +5,7 @@
 }(function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
-	var _hasOwnProperty = hasOwnProperty;
 
-	console.log( _hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 
 }));

--- a/test/bundle/output/umdDefaults/37.js
+++ b/test/bundle/output/umdDefaults/37.js
@@ -1,11 +1,11 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.moment)
-}(this, function (moment) { 'use strict';
+	factory(global.x)
+}(this, function (x) { 'use strict';
 
-	var x = 'wut';
-	var a = x;
+	var a__x = 'wut';
+	var a = a__x;
 
 
 

--- a/test/bundle/output/umdDefaults/55.js
+++ b/test/bundle/output/umdDefaults/55.js
@@ -6,23 +6,17 @@
 
 	class A {
 		b () {
-			return new _B();
+			return new B();
 		}
 
 		c () {
-			return new _C();
+			return new C();
 		}
 	}
 
-	var _A = A;
+	class B extends A {}
 
-	class B extends _A {}
-
-	var _B = B;
-
-	class C extends _A {}
-
-	var _C = C;
+	class C extends A {}
 
 
 

--- a/test/bundle/output/umdDefaults/56.js
+++ b/test/bundle/output/umdDefaults/56.js
@@ -4,8 +4,12 @@
 	factory()
 }(function () { 'use strict';
 
-	var hasOwnProperty = Object.prototype.hasOwnProperty;
+	var foo = 42;
+	var _foo = foo;
+	foo = 99;
+	foo += 1;
+	foo++;
 
-	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
+	console.log( _foo ); // 42
 
 }));


### PR DESCRIPTION
This scratches an itch I've had for quite some time. Due to the way esperanto avoids variable name conflicts, something like this...

```js
var foo = 42;
export default foo;
```

...gets transpiled to this inside a bundle:

```js
var foo = 42;
var _foo = foo;
```

A large enough codebase will be littered with this sort of thing. Or, if `foo.js` is inside a directory, say `utils`, it will come out as `var utils__foo = foo`, or something like that.

Clearly it's unnecessary - we should just use `foo` throughout. The one exception is where `foo` is updated or assigned to *after* it has been exported, since IIRC default bindings aren't live, like regular bindings (can't find the reference now, spotty wifi - correct me if I'm wrong!).

In other words, this...

```js
var foo = 42;
export default foo;
foo++;
```

...should become this:

```js
var foo = 42;
var _foo = foo;
foo++;
```

That edge case is dealt with, at the cost of some pretty funky code, which I might try and clean up a little before merging this in.

I've tried this out on a few examples and the difference is huge - the code looks handwritten rather than generated, and is accordingly much easier to read in its bundled state.