### PR TITLE
Remove `this` errors.

### DIFF
--- a/src/utils/ast/annotate.js
+++ b/src/utils/ast/annotate.js
@@ -104,9 +104,6 @@ export default function annotateAst ( ast, options ) {
 					break;
 
 				case 'MemberExpression':
-					if ( envDepth === 0 && node.object.type === 'ThisExpression' ) {
-						throw new Error('`this` at the top level is undefined');
-					}
 					!node.computed && ( node.property._skip = true );
 					break;
 

--- a/test/es6-module-transpiler-tests/input/this-binding-get-early-error/_config.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-get-early-error/_config.js
@@ -1,3 +1,0 @@
-module.exports = {
-	entry: 'mod',	expectedError: '`this` at the top level is undefined'
-};

--- a/test/es6-module-transpiler-tests/input/this-binding-get-early-error/mod.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-get-early-error/mod.js
@@ -1,1 +1,0 @@
-this.notThere();

--- a/test/es6-module-transpiler-tests/input/this-binding-set-early-error/_config.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-set-early-error/_config.js
@@ -1,3 +1,0 @@
-module.exports = {
-	entry: 'mod',	expectedError: '`this` at the top level is undefined'
-};

--- a/test/es6-module-transpiler-tests/input/this-binding-set-early-error/mod.js
+++ b/test/es6-module-transpiler-tests/input/this-binding-set-early-error/mod.js
@@ -1,1 +1,0 @@
-this.notThere = function () {};


### PR DESCRIPTION
This PR for #151 removes the `this` errors because it's erring on valid code. This kind of checking should be left to a linter.