### PR TITLE
Use Rollup

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -6,8 +6,7 @@
 		"es6.blockScoping",
 		"es6.constants",
 		"es6.destructuring",
-		"es6.parameters.default",
-		"es6.parameters.rest",
+		"es6.parameters",
 		"es6.properties.shorthand",
 		"es6.templateLiterals",
 		"es6.classes"

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "chalk": "^1.0.0",
     "magic-string": "^0.4.9",
     "minimist": "^1.1.0",
+    "rollup": "^0.11.4",
     "sander": "^0.2.1"
   },
   "main": "dist/esperanto.js",

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
     "gobble-esperanto-bundle": "^0.2.0",
     "gobble-uglifyjs": "^0.1.0",
     "magic-string": "^0.6.0",
-    "mocha": "^2.1.0",
+    "mocha": "^2.2.5",
     "resolve": "^1.1.0",
     "source-map": "^0.1.40",
     "source-map-support": "^0.2.10"

--- a/src/esperanto.js
+++ b/src/esperanto.js
@@ -132,14 +132,22 @@ export function bundle ( options ) {
 				alreadyWarned = true;
 			}
 
-			return bundle.generate({
+			const result = bundle.generate({
 				format,
 				moduleName: bundleOptions.name,
 				moduleId: bundleOptions.amdName,
 				globals: options.names,
 				exports: bundle.exports.length ? ( bundleOptions.strict ? 'named' : 'default' ) : 'none',
-				useStrict: !!bundleOptions.useStrict
+				useStrict: bundleOptions.useStrict,
+				sourceMap: bundleOptions.sourceMap
 			});
+
+			if ( bundleOptions.sourceMap === 'inline' ) {
+				result.code += '\n//# sourceMappingURL=' + result.map.toUrl();
+				result.map = null;
+			}
+
+			return result;
 		}
 
 		return {

--- a/src/esperanto.js
+++ b/src/esperanto.js
@@ -67,22 +67,21 @@ export function bundle ( options ) {
 
 			return bundle.generate({
 				format,
-				exports: options.strict ? 'named' : 'default'
+				exports: bundle.imports.length || bundle.exports.length ?
+					( options.strict ? 'named' : 'default' ) :
+					'none'
 			});
 		}
 
 		return {
-			imports: [ 'TK imports' ],
-			exports: [ 'TK exports' ],
+			imports: bundle.imports,
+			exports: bundle.exports,
 
 			toAmd: options => transpile( 'amd', options ),
 			toCjs: options => transpile( 'cjs', options ),
 			toUmd: options => transpile( 'umd', options ),
 
-			concat: options => {
-				throw new Error( 'TK concat' );
-				//return concat( bundle, options || {} );
-			}
+			concat: options => transpile( 'iife', options )
 		};
 	});
 

--- a/test/bundle/index.js
+++ b/test/bundle/index.js
@@ -75,7 +75,7 @@ module.exports = function () {
 			});
 
 			profiles = [
-				{ description: 'bundle.concat()', method: 'concat', outputdir: 'concat' },
+				{ description: 'bundle.concat()', method: 'concat', outputdir: 'concat', options: { name: 'myModule' } },
 				{ description: 'bundle.toAmd()', method: 'toAmd', outputdir: 'amdDefaults' },
 				{ description: 'bundle.toUmd()', method: 'toUmd', outputdir: 'umdDefaults', options: { name: 'myModule' } },
 				{ description: 'bundle.toCjs()', method: 'toCjs', outputdir: 'cjsDefaults' },
@@ -145,7 +145,7 @@ module.exports = function () {
 											throw new Error( 'Test should fail in non-strict mode' );
 										}
 
-										assert.equal( actual, expected, 'Expected\n>\n' + actual + '\n>\n\nto match\n\n>\n' + expected + '\n>' );
+										assert.equal( actual, expected );
 									}).catch( function ( err ) {
 										if ( err.code === 'ENOENT' ) {
 											assert.equal( actual, '', 'Expected\n>\n' + actual + '\n>\n\nto match non-existent file' );
@@ -155,7 +155,7 @@ module.exports = function () {
 									});
 								}).catch( function ( err ) {
 									// strict mode tests should fail
-									if ( /strict mode/.test( err.message ) && config.strict ) {
+									if ( /was specified/.test( err.message ) && config.strict ) {
 										return;
 									}
 

--- a/test/bundle/input/06/main.js
+++ b/test/bundle/input/06/main.js
@@ -1,3 +1,3 @@
 import message from 'nested/foo';
 import external from 'utils/external';
-console.log( message );
+console.log( external( message ) );

--- a/test/bundle/input/08/main.js
+++ b/test/bundle/input/08/main.js
@@ -1,1 +1,2 @@
 import ImplicitlyNamed from 'external';
+new ImplicitlyNamed();

--- a/test/bundle/input/09/main.js
+++ b/test/bundle/input/09/main.js
@@ -1,1 +1,2 @@
 import ExplicitlyNamed from 'external';
+new ExplicitlyNamed();

--- a/test/bundle/input/12/main.js
+++ b/test/bundle/input/12/main.js
@@ -1,1 +1,2 @@
 import { bar } from './foo';
+bar();

--- a/test/bundle/input/14/main.js
+++ b/test/bundle/input/14/main.js
@@ -1,2 +1,2 @@
-import foo from './external';
+import foo from 'external';
 foo();

--- a/test/bundle/input/15/main.js
+++ b/test/bundle/input/15/main.js
@@ -1,2 +1,2 @@
-import { foo } from './external';
+import { foo } from 'external';
 foo();

--- a/test/bundle/input/16/main.js
+++ b/test/bundle/input/16/main.js
@@ -3,4 +3,5 @@ import b from './b';
 
 function foo () {
 	a();
+	b();
 }

--- a/test/bundle/input/18/main.js
+++ b/test/bundle/input/18/main.js
@@ -1,5 +1,5 @@
 import foo from './foo';
 import bar from './bar';
 
-// foo();
-// bar();
+foo();
+bar();

--- a/test/bundle/input/29/main.js
+++ b/test/bundle/input/29/main.js
@@ -1,4 +1,4 @@
-import foo, { bar } from './foo';
+import foo, { bar } from 'foo';
 
 foo();
 bar();

--- a/test/bundle/input/33/main.js
+++ b/test/bundle/input/33/main.js
@@ -6,3 +6,7 @@ var promise = new Promise();
 promise.keep();
 
 console.log( Math.add( 40, 2 ) );
+
+foo().then( function ( num ) {
+	console.log( num );
+});

--- a/test/bundle/input/37/_config.js
+++ b/test/bundle/input/37/_config.js
@@ -1,4 +1,7 @@
 module.exports = {
 	description: 'Clashes with external dependency names are handled',
-	imports: [ 'moment' ]
+	imports: [ 'moment' ],
+	names: {
+		moment: 'moment'
+	}
 };

--- a/test/bundle/input/37/main.js
+++ b/test/bundle/input/37/main.js
@@ -1,2 +1,4 @@
 import x from "moment";
 import a from './a';
+x();
+console.log( a );

--- a/test/bundle/input/39/_config.js
+++ b/test/bundle/input/39/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	description: 'avoids naming collisions between imports',
-	error: /Duplicated import \('x'\)/
+	error: /Duplicated import 'x'/
 };

--- a/test/bundle/input/44/a.js
+++ b/test/bundle/input/44/a.js
@@ -1,1 +1,2 @@
 import foo from 'foo';
+export default foo;

--- a/test/bundle/input/51/main.js
+++ b/test/bundle/input/51/main.js
@@ -1,2 +1,4 @@
 import highlight from 'highlight.js';
 import foo from './foo.js';
+
+highlight( foo );

--- a/test/bundle/input/54/_config.js
+++ b/test/bundle/input/54/_config.js
@@ -1,4 +1,7 @@
 module.exports = {
 	description: 'allows multiple modules to share an external package',
-	imports: [ 'bluebird' ]
+	imports: [ 'bluebird' ],
+	names: {
+		bluebird: 'Promise'
+	}
 };

--- a/test/bundle/input/54/main.js
+++ b/test/bundle/input/54/main.js
@@ -1,2 +1,6 @@
 import Promise from 'bluebird';
 import foo from './foo';
+
+Promise.resolve( foo ).then( function ( foo ) {
+	console.log( foo );
+});

--- a/test/bundle/input/55/main.js
+++ b/test/bundle/input/55/main.js
@@ -1,1 +1,2 @@
 import A from './A';
+new A();

--- a/test/bundle/output/amd/01.js
+++ b/test/bundle/output/amd/01.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/amd/02.js
+++ b/test/bundle/output/amd/02.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/amd/03.js
+++ b/test/bundle/output/amd/03.js
@@ -1,8 +1,6 @@
-define(['external'], function (external) {
+define(['external'], function (external) { 'use strict';
 
-	'use strict';
-
-	external = ('default' in external ? external['default'] : external);
+	external = 'default' in external ? external['default'] : external;
 
 	var bar = 'yes';
 	var foo = bar;

--- a/test/bundle/output/amd/04.js
+++ b/test/bundle/output/amd/04.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var answer = 42;
 

--- a/test/bundle/output/amd/05.js
+++ b/test/bundle/output/amd/05.js
@@ -4,14 +4,10 @@ define(['exports'], function (exports) { 'use strict';
 	var two = 2;
 	var three = 3;
 
-	var four = one + 3;
-	var five = two + 3;
-	var six = three + 3;
+	exports.four = one + 3;
+	exports.five = two + 3;
+	exports.six = three + 3;
 
-	four = 99;
-
-	exports.four = four;
-	exports.five = five;
-	exports.six = six;
+	exports.four = 99;
 
 });

--- a/test/bundle/output/amd/05.js
+++ b/test/bundle/output/amd/05.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var one = 1;
 	var two = 2;

--- a/test/bundle/output/amd/06.js
+++ b/test/bundle/output/amd/06.js
@@ -1,6 +1,4 @@
-define(['utils/external'], function (external) {
-
-	'use strict';
+define(['utils/external'], function (external) { 'use strict';
 
 	external = ('default' in external ? external['default'] : external);
 

--- a/test/bundle/output/amd/07.js
+++ b/test/bundle/output/amd/07.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 'this is foo';
 

--- a/test/bundle/output/amd/08.js
+++ b/test/bundle/output/amd/08.js
@@ -1,6 +1,4 @@
-define(['external'], function (ImplicitlyNamed) {
-
-	'use strict';
+define(['external'], function (ImplicitlyNamed) { 'use strict';
 
 	ImplicitlyNamed = ('default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed);
 

--- a/test/bundle/output/amd/09.js
+++ b/test/bundle/output/amd/09.js
@@ -1,6 +1,4 @@
-define(['external'], function (Correct) {
-
-	'use strict';
+define(['external'], function (Correct) { 'use strict';
 
 	Correct = ('default' in Correct ? Correct['default'] : Correct);
 

--- a/test/bundle/output/amd/10.js
+++ b/test/bundle/output/amd/10.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	class Foo {
 		constructor( str ) {

--- a/test/bundle/output/amd/11.js
+++ b/test/bundle/output/amd/11.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var foo = 1;
 	var bar = 2;

--- a/test/bundle/output/amd/11.js
+++ b/test/bundle/output/amd/11.js
@@ -1,20 +1,15 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var foo = 1;
-	var bar = 2;
-
-	foo = 3;
-
-	exports.foo = foo;
-	exports.bar = bar;
-
 	var baz = 4;
 
+	exports.foo = 1;
+	exports.bar = 2;
+
+	exports.foo = 3;
+
+	exports.qux = 5;
+	exports.qux = 6;
+
 	exports.baz = baz;
-
-	var qux = 5;
-	qux = 6;
-
-	exports.qux = qux;
 
 });

--- a/test/bundle/output/amd/14.js
+++ b/test/bundle/output/amd/14.js
@@ -1,6 +1,4 @@
-define(['external'], function (foo) {
-
-	'use strict';
+define(['external'], function (foo) { 'use strict';
 
 	foo = ('default' in foo ? foo['default'] : foo);
 

--- a/test/bundle/output/amd/15.js
+++ b/test/bundle/output/amd/15.js
@@ -1,6 +1,4 @@
-define(['external'], function (external) {
-
-	'use strict';
+define(['external'], function (external) { 'use strict';
 
 	external.foo();
 

--- a/test/bundle/output/amd/16.js
+++ b/test/bundle/output/amd/16.js
@@ -1,20 +1,21 @@
 define(function () { 'use strict';
 
-	function _a__a () {
-		console.log( 'a' );
-	}
-
-	function c__a () {
+	function _a () {
 		console.log( 'a but actually c' );
 	}
 
-	var b = function () {
+	function b () {
 		// a but actually c
-		c__a();
+		_a();
+	}
+
+	function a () {
+		console.log( 'a' );
 	}
 
 	function foo () {
-		_a__a();
+		a();
+		b();
 	}
 
 });

--- a/test/bundle/output/amd/16.js
+++ b/test/bundle/output/amd/16.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function _a__a () {
 		console.log( 'a' );

--- a/test/bundle/output/amd/17.js
+++ b/test/bundle/output/amd/17.js
@@ -1,13 +1,13 @@
 define(function () { 'use strict';
 
-	function foo__a ( message ) {
+	function a ( message ) {
 		console.log( message );
 	}
 
-	foo__a();
+	a();
 	(function () {
-		var a = 'c';
-		foo__a( a );
+		var a$$ = 'c';
+		a( a$$ );
 	}());
 
 });

--- a/test/bundle/output/amd/17.js
+++ b/test/bundle/output/amd/17.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo__a ( message ) {
 		console.log( message );

--- a/test/bundle/output/amd/18.js
+++ b/test/bundle/output/amd/18.js
@@ -1,14 +1,14 @@
 define(function () { 'use strict';
 
-	var _doThing = function () {
+	function _doThing () {
 		console.log( 'doing foo thing' );
 	}
 
-	var foo = function () {
+	function foo () {
 		_doThing();
 	}
 
-	var bar = function () {
+	function bar () {
 		doThing();
 	}
 
@@ -16,6 +16,7 @@ define(function () { 'use strict';
 		console.log( 'doing bar thing' );
 	}
 
-
+	foo();
+	bar();
 
 });

--- a/test/bundle/output/amd/18.js
+++ b/test/bundle/output/amd/18.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _doThing = function () {
 		console.log( 'doing foo thing' );

--- a/test/bundle/output/amd/19.js
+++ b/test/bundle/output/amd/19.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/amd/20.js
+++ b/test/bundle/output/amd/20.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/amd/21.js
+++ b/test/bundle/output/amd/21.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	const config = {};
 

--- a/test/bundle/output/amd/22.js
+++ b/test/bundle/output/amd/22.js
@@ -4,8 +4,10 @@ define(['exports'], function (exports) { 'use strict';
 		console.log( 'fooing' );
 	}
 
-	exports.foo = foo;
 
+	// foo
 	foo();
+
+	exports.foo = foo;
 
 });

--- a/test/bundle/output/amd/22.js
+++ b/test/bundle/output/amd/22.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/bundle/output/amd/24.js
+++ b/test/bundle/output/amd/24.js
@@ -1,7 +1,5 @@
 /* this is a banner */
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/bundle/output/amd/25.js
+++ b/test/bundle/output/amd/25.js
@@ -1,6 +1,4 @@
-define('myModule', function () {
-
-	'use strict';
+define('myModule', function () { 'use strict';
 
 	var foo = function () {
 		console.log( 'fooing' );

--- a/test/bundle/output/amd/25.js
+++ b/test/bundle/output/amd/25.js
@@ -1,6 +1,6 @@
 define('myModule', function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'fooing' );
 	}
 

--- a/test/bundle/output/amd/26.js
+++ b/test/bundle/output/amd/26.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function bar () {
 		console.log( 'baring' );

--- a/test/bundle/output/amd/27.js
+++ b/test/bundle/output/amd/27.js
@@ -1,6 +1,4 @@
-define(function () {
-
-  'use strict';
+define(function () { 'use strict';
 
   var foo = 'this is foo';
 

--- a/test/bundle/output/amd/28.js
+++ b/test/bundle/output/amd/28.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = () => undefined;
 

--- a/test/bundle/output/amd/29.js
+++ b/test/bundle/output/amd/29.js
@@ -1,6 +1,4 @@
-define(['foo'], function (foo) {
-
-	'use strict';
+define(['foo'], function (foo) { 'use strict';
 
 	var foo__default = ('default' in foo ? foo['default'] : foo);
 

--- a/test/bundle/output/amd/30.js
+++ b/test/bundle/output/amd/30.js
@@ -1,6 +1,4 @@
-define(['foo'], function (foo) {
-
-	'use strict';
+define(['foo'], function (foo) { 'use strict';
 
 	foo.bar();
 

--- a/test/bundle/output/amd/31.js
+++ b/test/bundle/output/amd/31.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function someOtherName () {}
 

--- a/test/bundle/output/amd/31.js
+++ b/test/bundle/output/amd/31.js
@@ -1,8 +1,8 @@
 define(function () { 'use strict';
 
-	function someOtherName () {}
+	function _x () {}
 
-	function x () {}
+	function someOtherName () {}
 
 	someOtherName();
 

--- a/test/bundle/output/amd/32.js
+++ b/test/bundle/output/amd/32.js
@@ -1,5 +1,3 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 });

--- a/test/bundle/output/amd/32.js
+++ b/test/bundle/output/amd/32.js
@@ -1,3 +1,5 @@
 define(function () { 'use strict';
 
+
+
 });

--- a/test/bundle/output/amd/33.js
+++ b/test/bundle/output/amd/33.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _Promise__Promise = function () {};
 

--- a/test/bundle/output/amd/33.js
+++ b/test/bundle/output/amd/33.js
@@ -1,17 +1,15 @@
 define(function () { 'use strict';
 
-	var _Promise__Promise = function () {};
-
-	_Promise__Promise.prototype = {
-		keep () { this.state = 'kept'; },
-		break () { this.state = 'broken'; }
-	};
-
-	var _Promise = _Promise__Promise;
-
 	var _Math = {
 		get add () { return add; },
 		get multiply () { return multiply; }
+	};
+
+	var _Promise = function () {};
+
+	_Promise.prototype = {
+		keep () { this.state = 'kept'; },
+		break () { this.state = 'broken'; }
 	};
 
 	function add ( a, b ) {
@@ -33,5 +31,9 @@ define(function () { 'use strict';
 	promise.keep();
 
 	console.log( _Math.add( 40, 2 ) );
+
+	foo().then( function ( num ) {
+		console.log( num );
+	});
 
 });

--- a/test/bundle/output/amd/34.js
+++ b/test/bundle/output/amd/34.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var foo__exports = {};
 	foo__exports.bar = function () {

--- a/test/bundle/output/amd/35.js
+++ b/test/bundle/output/amd/35.js
@@ -1,9 +1,5 @@
 define(function () { 'use strict';
 
-	function a () {
-		console.log( 'I am module a' );
-	}
-
 	function c () {
 		console.log( 'I am module c' );
 	}
@@ -11,6 +7,10 @@ define(function () { 'use strict';
 	function b () {
 		console.log( 'I am module b' );
 		c();
+	}
+
+	function a () {
+		console.log( 'I am module a' );
 	}
 
 	function external () {

--- a/test/bundle/output/amd/35.js
+++ b/test/bundle/output/amd/35.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function a () {
 		console.log( 'I am module a' );

--- a/test/bundle/output/amd/36.js
+++ b/test/bundle/output/amd/36.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function dependsOnExternal () {
 		console.log( external.message );

--- a/test/bundle/output/amd/37.js
+++ b/test/bundle/output/amd/37.js
@@ -1,6 +1,4 @@
-define(['moment'], function (x) {
-
-	'use strict';
+define(['moment'], function (x) { 'use strict';
 
 	x = ('default' in x ? x['default'] : x);
 

--- a/test/bundle/output/amd/38.js
+++ b/test/bundle/output/amd/38.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _foo = notActuallyFoo;
 

--- a/test/bundle/output/amd/40.js
+++ b/test/bundle/output/amd/40.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amd/42.js
+++ b/test/bundle/output/amd/42.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amd/43.js
+++ b/test/bundle/output/amd/43.js
@@ -1,6 +1,4 @@
-define(['bar'], function (Bar) {
-
-	'use strict';
+define(['bar'], function (Bar) { 'use strict';
 
 	Bar = ('default' in Bar ? Bar['default'] : Bar);
 

--- a/test/bundle/output/amd/44.js
+++ b/test/bundle/output/amd/44.js
@@ -1,6 +1,4 @@
-define(['foo', 'bar'], function (foo, _bar) {
-
-	'use strict';
+define(['foo', 'bar'], function (foo, _bar) { 'use strict';
 
 	foo = ('default' in foo ? foo['default'] : foo);
 	_bar = ('default' in _bar ? _bar['default'] : _bar);

--- a/test/bundle/output/amd/45.js
+++ b/test/bundle/output/amd/45.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/amd/46.js
+++ b/test/bundle/output/amd/46.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/amd/48.js
+++ b/test/bundle/output/amd/48.js
@@ -1,6 +1,4 @@
-define(['external'], function (external) {
-
-	'use strict';
+define(['external'], function (external) { 'use strict';
 
 	external = ('default' in external ? external['default'] : external);
 

--- a/test/bundle/output/amd/49.js
+++ b/test/bundle/output/amd/49.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amd/50.js
+++ b/test/bundle/output/amd/50.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	class A {
 		constructor () {

--- a/test/bundle/output/amd/51.js
+++ b/test/bundle/output/amd/51.js
@@ -1,6 +1,4 @@
-define(['highlight.js'], function (highlight) {
-
-	'use strict';
+define(['highlight.js'], function (highlight) { 'use strict';
 
 	highlight = ('default' in highlight ? highlight['default'] : highlight);
 

--- a/test/bundle/output/amd/52.js
+++ b/test/bundle/output/amd/52.js
@@ -1,13 +1,11 @@
 define(function () { 'use strict';
 
-	var not_baz = function () {
+	function baz () {
 		// baz.js
-	};
+	}
 
 
-
-	console.log( 'baz', not_baz );
-
-
+	// bar.js
+	console.log( 'baz', baz );
 
 });

--- a/test/bundle/output/amd/52.js
+++ b/test/bundle/output/amd/52.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var not_baz = function () {
 		// baz.js

--- a/test/bundle/output/amd/53.js
+++ b/test/bundle/output/amd/53.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var foo = function () {
 		console.log( 'foo' );

--- a/test/bundle/output/amd/53.js
+++ b/test/bundle/output/amd/53.js
@@ -1,12 +1,12 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'foo' );
 	}
 
 	foo();
 
-	var main = function () {
+	function main () {
 		console.log( 'main' );
 	}
 

--- a/test/bundle/output/amd/54.js
+++ b/test/bundle/output/amd/54.js
@@ -1,6 +1,4 @@
-define(['bluebird'], function (bluebird) {
-
-	'use strict';
+define(['bluebird'], function (bluebird) { 'use strict';
 
 	bluebird = ('default' in bluebird ? bluebird['default'] : bluebird);
 

--- a/test/bundle/output/amd/55.js
+++ b/test/bundle/output/amd/55.js
@@ -10,10 +10,10 @@ define(function () { 'use strict';
 		}
 	}
 
-	class B extends A {}
-
 	class C extends A {}
 
+	class B extends A {}
 
+	new A();
 
 });

--- a/test/bundle/output/amd/55.js
+++ b/test/bundle/output/amd/55.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	class A {
 		b () {

--- a/test/bundle/output/amd/56.js
+++ b/test/bundle/output/amd/56.js
@@ -6,6 +6,6 @@ define(function () { 'use strict';
 	foo += 1;
 	foo++;
 
-	console.log( _foo ); // 42
+	console.log( _foo );
 
 });

--- a/test/bundle/output/amd/56.js
+++ b/test/bundle/output/amd/56.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 42;
 	var _foo = foo;

--- a/test/bundle/output/amd/57.js
+++ b/test/bundle/output/amd/57.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = {
 		get y () { return x; }

--- a/test/bundle/output/amd/58.js
+++ b/test/bundle/output/amd/58.js
@@ -1,6 +1,4 @@
-define(['exports'], function (exports) {
-
-	'use strict';
+define(['exports'], function (exports) { 'use strict';
 
 	var x = 42;
 

--- a/test/bundle/output/amd/58.js
+++ b/test/bundle/output/amd/58.js
@@ -1,7 +1,5 @@
 define(['exports'], function (exports) { 'use strict';
 
-	var x = 42;
-
-	exports.y = x;
+	exports.y = 42;
 
 });

--- a/test/bundle/output/amd/59.js
+++ b/test/bundle/output/amd/59.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 'foo';
 

--- a/test/bundle/output/amd/59.js
+++ b/test/bundle/output/amd/59.js
@@ -2,6 +2,6 @@ define(function () { 'use strict';
 
 	var foo = 'foo';
 
-	console.log( foo ); // 'foo'
+	console.log( foo );
 
 });

--- a/test/bundle/output/amdDefaults/01.js
+++ b/test/bundle/output/amdDefaults/01.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/amdDefaults/02.js
+++ b/test/bundle/output/amdDefaults/02.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/amdDefaults/03.js
+++ b/test/bundle/output/amdDefaults/03.js
@@ -1,6 +1,6 @@
-define(['external'], function (external) {
+define(['external'], function (external) { 'use strict';
 
-	'use strict';
+	external = 'default' in external ? external['default'] : external;
 
 	var bar = 'yes';
 	var foo = bar;

--- a/test/bundle/output/amdDefaults/04.js
+++ b/test/bundle/output/amdDefaults/04.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var answer = 42;
 

--- a/test/bundle/output/amdDefaults/06.js
+++ b/test/bundle/output/amdDefaults/06.js
@@ -1,7 +1,9 @@
 define(['utils/external'], function (external) { 'use strict';
 
+	external = 'default' in external ? external['default'] : external;
+
 	var message = 'this is a message';
 
-	console.log( message );
+	console.log( external( message ) );
 
 });

--- a/test/bundle/output/amdDefaults/06.js
+++ b/test/bundle/output/amdDefaults/06.js
@@ -1,6 +1,4 @@
-define(['utils/external'], function (external) {
-
-	'use strict';
+define(['utils/external'], function (external) { 'use strict';
 
 	var message = 'this is a message';
 

--- a/test/bundle/output/amdDefaults/07.js
+++ b/test/bundle/output/amdDefaults/07.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 'this is foo';
 

--- a/test/bundle/output/amdDefaults/08.js
+++ b/test/bundle/output/amdDefaults/08.js
@@ -1,3 +1,7 @@
 define(['external'], function (ImplicitlyNamed) { 'use strict';
 
+	ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
+
+	new ImplicitlyNamed();
+
 });

--- a/test/bundle/output/amdDefaults/08.js
+++ b/test/bundle/output/amdDefaults/08.js
@@ -1,5 +1,3 @@
-define(['external'], function (ImplicitlyNamed) {
-
-	'use strict';
+define(['external'], function (ImplicitlyNamed) { 'use strict';
 
 });

--- a/test/bundle/output/amdDefaults/09.js
+++ b/test/bundle/output/amdDefaults/09.js
@@ -1,5 +1,3 @@
-define(['external'], function (Correct) {
-
-	'use strict';
+define(['external'], function (Correct) { 'use strict';
 
 });

--- a/test/bundle/output/amdDefaults/09.js
+++ b/test/bundle/output/amdDefaults/09.js
@@ -1,3 +1,7 @@
-define(['external'], function (Correct) { 'use strict';
+define(['external'], function (ExplicitlyNamed) { 'use strict';
+
+	ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
+
+	new ExplicitlyNamed();
 
 });

--- a/test/bundle/output/amdDefaults/10.js
+++ b/test/bundle/output/amdDefaults/10.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	class Foo {
 		constructor( str ) {

--- a/test/bundle/output/amdDefaults/14.js
+++ b/test/bundle/output/amdDefaults/14.js
@@ -1,6 +1,4 @@
-define(['external'], function (foo) {
-
-	'use strict';
+define(['external'], function (foo) { 'use strict';
 
 	foo();
 

--- a/test/bundle/output/amdDefaults/14.js
+++ b/test/bundle/output/amdDefaults/14.js
@@ -1,5 +1,7 @@
 define(['external'], function (foo) { 'use strict';
 
+	foo = 'default' in foo ? foo['default'] : foo;
+
 	foo();
 
 });

--- a/test/bundle/output/amdDefaults/15.js
+++ b/test/bundle/output/amdDefaults/15.js
@@ -1,0 +1,5 @@
+define(['external'], function (external) { 'use strict';
+
+	external.foo();
+
+});

--- a/test/bundle/output/amdDefaults/16.js
+++ b/test/bundle/output/amdDefaults/16.js
@@ -1,20 +1,21 @@
 define(function () { 'use strict';
 
-	function _a__a () {
-		console.log( 'a' );
-	}
-
-	function c__a () {
+	function _a () {
 		console.log( 'a but actually c' );
 	}
 
-	var b = function () {
+	function b () {
 		// a but actually c
-		c__a();
+		_a();
+	}
+
+	function a () {
+		console.log( 'a' );
 	}
 
 	function foo () {
-		_a__a();
+		a();
+		b();
 	}
 
 });

--- a/test/bundle/output/amdDefaults/16.js
+++ b/test/bundle/output/amdDefaults/16.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function _a__a () {
 		console.log( 'a' );

--- a/test/bundle/output/amdDefaults/17.js
+++ b/test/bundle/output/amdDefaults/17.js
@@ -1,13 +1,13 @@
 define(function () { 'use strict';
 
-	function foo__a ( message ) {
+	function a ( message ) {
 		console.log( message );
 	}
 
-	foo__a();
+	a();
 	(function () {
-		var a = 'c';
-		foo__a( a );
+		var a$$ = 'c';
+		a( a$$ );
 	}());
 
 });

--- a/test/bundle/output/amdDefaults/17.js
+++ b/test/bundle/output/amdDefaults/17.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo__a ( message ) {
 		console.log( message );

--- a/test/bundle/output/amdDefaults/18.js
+++ b/test/bundle/output/amdDefaults/18.js
@@ -1,14 +1,14 @@
 define(function () { 'use strict';
 
-	var _doThing = function () {
+	function _doThing () {
 		console.log( 'doing foo thing' );
 	}
 
-	var foo = function () {
+	function foo () {
 		_doThing();
 	}
 
-	var bar = function () {
+	function bar () {
 		doThing();
 	}
 
@@ -16,6 +16,7 @@ define(function () { 'use strict';
 		console.log( 'doing bar thing' );
 	}
 
-
+	foo();
+	bar();
 
 });

--- a/test/bundle/output/amdDefaults/18.js
+++ b/test/bundle/output/amdDefaults/18.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _doThing = function () {
 		console.log( 'doing foo thing' );

--- a/test/bundle/output/amdDefaults/19.js
+++ b/test/bundle/output/amdDefaults/19.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/amdDefaults/20.js
+++ b/test/bundle/output/amdDefaults/20.js
@@ -2,7 +2,7 @@ define(function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-	var main = function () {
+	function main () {
 		console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 	}
 

--- a/test/bundle/output/amdDefaults/20.js
+++ b/test/bundle/output/amdDefaults/20.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/amdDefaults/21.js
+++ b/test/bundle/output/amdDefaults/21.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	const config = {};
 

--- a/test/bundle/output/amdDefaults/24.js
+++ b/test/bundle/output/amdDefaults/24.js
@@ -1,7 +1,5 @@
 /* this is a banner */
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/bundle/output/amdDefaults/25.js
+++ b/test/bundle/output/amdDefaults/25.js
@@ -1,6 +1,4 @@
-define('myModule', function () {
-
-	'use strict';
+define('myModule', function () { 'use strict';
 
 	var foo = function () {
 		console.log( 'fooing' );

--- a/test/bundle/output/amdDefaults/25.js
+++ b/test/bundle/output/amdDefaults/25.js
@@ -1,6 +1,6 @@
 define('myModule', function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'fooing' );
 	}
 

--- a/test/bundle/output/amdDefaults/26.js
+++ b/test/bundle/output/amdDefaults/26.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function bar () {
 		console.log( 'baring' );

--- a/test/bundle/output/amdDefaults/27.js
+++ b/test/bundle/output/amdDefaults/27.js
@@ -1,6 +1,4 @@
-define(function () {
-
-  'use strict';
+define(function () { 'use strict';
 
   var foo = 'this is foo';
 

--- a/test/bundle/output/amdDefaults/28.js
+++ b/test/bundle/output/amdDefaults/28.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = () => undefined;
 

--- a/test/bundle/output/amdDefaults/29.js
+++ b/test/bundle/output/amdDefaults/29.js
@@ -1,6 +1,6 @@
 define(['foo'], function (foo) { 'use strict';
 
-	var foo__default = 'default' in foo ? foo['default'] : foo;
+	var foo__default = ('default' in foo ? foo['default'] : foo);
 
 	foo__default();
 	foo.bar();

--- a/test/bundle/output/amdDefaults/30.js
+++ b/test/bundle/output/amdDefaults/30.js
@@ -1,6 +1,4 @@
-define(['foo'], function (foo) {
-
-	'use strict';
+define(['foo'], function (foo) { 'use strict';
 
 	foo.bar();
 

--- a/test/bundle/output/amdDefaults/31.js
+++ b/test/bundle/output/amdDefaults/31.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function someOtherName () {}
 

--- a/test/bundle/output/amdDefaults/31.js
+++ b/test/bundle/output/amdDefaults/31.js
@@ -1,8 +1,8 @@
 define(function () { 'use strict';
 
-	function someOtherName () {}
+	function _x () {}
 
-	function x () {}
+	function someOtherName () {}
 
 	someOtherName();
 

--- a/test/bundle/output/amdDefaults/32.js
+++ b/test/bundle/output/amdDefaults/32.js
@@ -1,5 +1,3 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 });

--- a/test/bundle/output/amdDefaults/32.js
+++ b/test/bundle/output/amdDefaults/32.js
@@ -1,3 +1,5 @@
 define(function () { 'use strict';
 
+
+
 });

--- a/test/bundle/output/amdDefaults/33.js
+++ b/test/bundle/output/amdDefaults/33.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _Promise__Promise = function () {};
 

--- a/test/bundle/output/amdDefaults/33.js
+++ b/test/bundle/output/amdDefaults/33.js
@@ -1,17 +1,15 @@
 define(function () { 'use strict';
 
-	var _Promise__Promise = function () {};
-
-	_Promise__Promise.prototype = {
-		keep () { this.state = 'kept'; },
-		break () { this.state = 'broken'; }
-	};
-
-	var _Promise = _Promise__Promise;
-
 	var _Math = {
 		get add () { return add; },
 		get multiply () { return multiply; }
+	};
+
+	var _Promise = function () {};
+
+	_Promise.prototype = {
+		keep () { this.state = 'kept'; },
+		break () { this.state = 'broken'; }
 	};
 
 	function add ( a, b ) {
@@ -33,5 +31,9 @@ define(function () { 'use strict';
 	promise.keep();
 
 	console.log( _Math.add( 40, 2 ) );
+
+	foo().then( function ( num ) {
+		console.log( num );
+	});
 
 });

--- a/test/bundle/output/amdDefaults/34.js
+++ b/test/bundle/output/amdDefaults/34.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo__exports = {};
 	foo__exports.bar = function () {

--- a/test/bundle/output/amdDefaults/35.js
+++ b/test/bundle/output/amdDefaults/35.js
@@ -1,9 +1,5 @@
 define(function () { 'use strict';
 
-	function a () {
-		console.log( 'I am module a' );
-	}
-
 	function c () {
 		console.log( 'I am module c' );
 	}
@@ -11,6 +7,10 @@ define(function () { 'use strict';
 	function b () {
 		console.log( 'I am module b' );
 		c();
+	}
+
+	function a () {
+		console.log( 'I am module a' );
 	}
 
 	function external () {

--- a/test/bundle/output/amdDefaults/35.js
+++ b/test/bundle/output/amdDefaults/35.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function a () {
 		console.log( 'I am module a' );

--- a/test/bundle/output/amdDefaults/36.js
+++ b/test/bundle/output/amdDefaults/36.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function dependsOnExternal () {
 		console.log( external.message );

--- a/test/bundle/output/amdDefaults/37.js
+++ b/test/bundle/output/amdDefaults/37.js
@@ -1,8 +1,11 @@
 define(['moment'], function (x) { 'use strict';
 
-	var a__x = 'wut';
-	var a = a__x;
+	x = 'default' in x ? x['default'] : x;
 
+	var __x = 'wut';
+	var a = __x;
 
+	x();
+	console.log( a );
 
 });

--- a/test/bundle/output/amdDefaults/37.js
+++ b/test/bundle/output/amdDefaults/37.js
@@ -1,6 +1,4 @@
-define(['moment'], function (x) {
-
-	'use strict';
+define(['moment'], function (x) { 'use strict';
 
 	var a__x = 'wut';
 	var a = a__x;

--- a/test/bundle/output/amdDefaults/38.js
+++ b/test/bundle/output/amdDefaults/38.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var _foo = notActuallyFoo;
 

--- a/test/bundle/output/amdDefaults/40.js
+++ b/test/bundle/output/amdDefaults/40.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amdDefaults/42.js
+++ b/test/bundle/output/amdDefaults/42.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amdDefaults/43.js
+++ b/test/bundle/output/amdDefaults/43.js
@@ -1,5 +1,7 @@
 define(['bar'], function (Bar) { 'use strict';
 
+	Bar = 'default' in Bar ? Bar['default'] : Bar;
+
 	class Foo extends Bar {
 		constructor() {
 			super();

--- a/test/bundle/output/amdDefaults/43.js
+++ b/test/bundle/output/amdDefaults/43.js
@@ -1,6 +1,4 @@
-define(['bar'], function (Bar) {
-
-	'use strict';
+define(['bar'], function (Bar) { 'use strict';
 
 	class Foo extends Bar {
 		constructor() {

--- a/test/bundle/output/amdDefaults/44.js
+++ b/test/bundle/output/amdDefaults/44.js
@@ -1,6 +1,4 @@
-define(['foo', 'bar'], function (foo, _bar) {
-
-	'use strict';
+define(['foo', 'bar'], function (foo, _bar) { 'use strict';
 
 
 

--- a/test/bundle/output/amdDefaults/45.js
+++ b/test/bundle/output/amdDefaults/45.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/amdDefaults/46.js
+++ b/test/bundle/output/amdDefaults/46.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/amdDefaults/48.js
+++ b/test/bundle/output/amdDefaults/48.js
@@ -1,5 +1,7 @@
 define(['external'], function (external) { 'use strict';
 
+	external = 'default' in external ? external['default'] : external;
+
 	external();
 
 });

--- a/test/bundle/output/amdDefaults/48.js
+++ b/test/bundle/output/amdDefaults/48.js
@@ -1,6 +1,4 @@
-define(['external'], function (external) {
-
-	'use strict';
+define(['external'], function (external) { 'use strict';
 
 	external();
 

--- a/test/bundle/output/amdDefaults/49.js
+++ b/test/bundle/output/amdDefaults/49.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/amdDefaults/50.js
+++ b/test/bundle/output/amdDefaults/50.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	class A {
 		constructor () {

--- a/test/bundle/output/amdDefaults/51.js
+++ b/test/bundle/output/amdDefaults/51.js
@@ -1,7 +1,9 @@
 define(['highlight.js'], function (highlight) { 'use strict';
 
+	highlight = 'default' in highlight ? highlight['default'] : highlight;
+
 	var foo = 42;
 
-
+	highlight( foo );
 
 });

--- a/test/bundle/output/amdDefaults/51.js
+++ b/test/bundle/output/amdDefaults/51.js
@@ -1,6 +1,4 @@
-define(['highlight.js'], function (highlight) {
-
-	'use strict';
+define(['highlight.js'], function (highlight) { 'use strict';
 
 	var foo = 42;
 

--- a/test/bundle/output/amdDefaults/52.js
+++ b/test/bundle/output/amdDefaults/52.js
@@ -1,13 +1,11 @@
 define(function () { 'use strict';
 
-	var not_baz = function () {
+	function baz () {
 		// baz.js
-	};
+	}
 
 
-
-	console.log( 'baz', not_baz );
-
-
+	// bar.js
+	console.log( 'baz', baz );
 
 });

--- a/test/bundle/output/amdDefaults/52.js
+++ b/test/bundle/output/amdDefaults/52.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var not_baz = function () {
 		// baz.js

--- a/test/bundle/output/amdDefaults/53.js
+++ b/test/bundle/output/amdDefaults/53.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = function () {
 		console.log( 'foo' );

--- a/test/bundle/output/amdDefaults/54.js
+++ b/test/bundle/output/amdDefaults/54.js
@@ -1,6 +1,4 @@
-define(['bluebird'], function (bluebird) {
-
-	'use strict';
+define(['bluebird'], function (bluebird) { 'use strict';
 
 	var foo = 'foo';
 

--- a/test/bundle/output/amdDefaults/54.js
+++ b/test/bundle/output/amdDefaults/54.js
@@ -1,7 +1,11 @@
-define(['bluebird'], function (bluebird) { 'use strict';
+define(['bluebird'], function (_Promise) { 'use strict';
+
+	_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
 	var foo = 'foo';
 
-
+	_Promise.resolve( foo ).then( function ( foo ) {
+		console.log( foo );
+	});
 
 });

--- a/test/bundle/output/amdDefaults/55.js
+++ b/test/bundle/output/amdDefaults/55.js
@@ -10,10 +10,10 @@ define(function () { 'use strict';
 		}
 	}
 
-	class B extends A {}
-
 	class C extends A {}
 
+	class B extends A {}
 
+	new A();
 
 });

--- a/test/bundle/output/amdDefaults/55.js
+++ b/test/bundle/output/amdDefaults/55.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	class A {
 		b () {

--- a/test/bundle/output/amdDefaults/56.js
+++ b/test/bundle/output/amdDefaults/56.js
@@ -6,6 +6,6 @@ define(function () { 'use strict';
 	foo += 1;
 	foo++;
 
-	console.log( _foo ); // 42
+	console.log( _foo );
 
 });

--- a/test/bundle/output/amdDefaults/56.js
+++ b/test/bundle/output/amdDefaults/56.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 42;
 	var _foo = foo;

--- a/test/bundle/output/amdDefaults/57.js
+++ b/test/bundle/output/amdDefaults/57.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = {
 		get y () { return x; }

--- a/test/bundle/output/amdDefaults/59.js
+++ b/test/bundle/output/amdDefaults/59.js
@@ -1,6 +1,4 @@
-define(function () {
-
-	'use strict';
+define(function () { 'use strict';
 
 	var foo = 'foo';
 

--- a/test/bundle/output/amdDefaults/59.js
+++ b/test/bundle/output/amdDefaults/59.js
@@ -2,6 +2,6 @@ define(function () { 'use strict';
 
 	var foo = 'foo';
 
-	console.log( foo ); // 'foo'
+	console.log( foo );
 
 });

--- a/test/bundle/output/cjs/03.js
+++ b/test/bundle/output/cjs/03.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var external = require('external');
-external = ('default' in external ? external['default'] : external);
+external = 'default' in external ? external['default'] : external;
 
 var bar = 'yes';
 var foo = bar;

--- a/test/bundle/output/cjs/05.js
+++ b/test/bundle/output/cjs/05.js
@@ -4,12 +4,8 @@ var one = 1;
 var two = 2;
 var three = 3;
 
-var four = one + 3;
-var five = two + 3;
-var six = three + 3;
+exports.four = one + 3;
+exports.five = two + 3;
+exports.six = three + 3;
 
-four = 99;
-
-exports.four = four;
-exports.five = five;
-exports.six = six;
+exports.four = 99;

--- a/test/bundle/output/cjs/06.js
+++ b/test/bundle/output/cjs/06.js
@@ -1,8 +1,8 @@
 'use strict';
 
 var external = require('utils/external');
-external = ('default' in external ? external['default'] : external);
+external = 'default' in external ? external['default'] : external;
 
 var message = 'this is a message';
 
-console.log( message );
+console.log( external( message ) );

--- a/test/bundle/output/cjs/08.js
+++ b/test/bundle/output/cjs/08.js
@@ -1,4 +1,6 @@
 'use strict';
 
 var ImplicitlyNamed = require('external');
-ImplicitlyNamed = ('default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed);
+ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
+
+new ImplicitlyNamed();

--- a/test/bundle/output/cjs/09.js
+++ b/test/bundle/output/cjs/09.js
@@ -1,4 +1,6 @@
 'use strict';
 
-var Correct = require('external');
-Correct = 'default' in Correct ? Correct['default'] : Correct;
+var ExplicitlyNamed = require('external');
+ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
+
+new ExplicitlyNamed();

--- a/test/bundle/output/cjs/09.js
+++ b/test/bundle/output/cjs/09.js
@@ -1,4 +1,4 @@
 'use strict';
 
 var Correct = require('external');
-Correct = ('default' in Correct ? Correct['default'] : Correct);
+Correct = 'default' in Correct ? Correct['default'] : Correct;

--- a/test/bundle/output/cjs/11.js
+++ b/test/bundle/output/cjs/11.js
@@ -1,18 +1,13 @@
 'use strict';
 
-var foo = 1;
-var bar = 2;
-
-foo = 3;
-
-exports.foo = foo;
-exports.bar = bar;
-
 var baz = 4;
 
+exports.foo = 1;
+exports.bar = 2;
+
+exports.foo = 3;
+
+exports.qux = 5;
+exports.qux = 6;
+
 exports.baz = baz;
-
-var qux = 5;
-qux = 6;
-
-exports.qux = qux;

--- a/test/bundle/output/cjs/14.js
+++ b/test/bundle/output/cjs/14.js
@@ -1,6 +1,6 @@
 'use strict';
 
 var foo = require('external');
-foo = ('default' in foo ? foo['default'] : foo);
+foo = 'default' in foo ? foo['default'] : foo;
 
 foo();

--- a/test/bundle/output/cjs/16.js
+++ b/test/bundle/output/cjs/16.js
@@ -1,18 +1,19 @@
 'use strict';
 
-function _a__a () {
-	console.log( 'a' );
-}
-
-function c__a () {
+function _a () {
 	console.log( 'a but actually c' );
 }
 
-var b = function () {
+function b () {
 	// a but actually c
-	c__a();
+	_a();
+}
+
+function a () {
+	console.log( 'a' );
 }
 
 function foo () {
-	_a__a();
+	a();
+	b();
 }

--- a/test/bundle/output/cjs/17.js
+++ b/test/bundle/output/cjs/17.js
@@ -1,11 +1,11 @@
 'use strict';
 
-function foo__a ( message ) {
+function a ( message ) {
 	console.log( message );
 }
 
-foo__a();
+a();
 (function () {
-	var a = 'c';
-	foo__a( a );
+	var a$$ = 'c';
+	a( a$$ );
 }());

--- a/test/bundle/output/cjs/18.js
+++ b/test/bundle/output/cjs/18.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _doThing = function () {
+function _doThing () {
 	console.log( 'doing foo thing' );
 }
 
-var foo = function () {
+function foo () {
 	_doThing();
 }
 
-var bar = function () {
+function bar () {
 	doThing();
 }
 
@@ -16,3 +16,5 @@ var doThing = function ( item ) {
 	console.log( 'doing bar thing' );
 }
 
+foo();
+bar();

--- a/test/bundle/output/cjs/20.js
+++ b/test/bundle/output/cjs/20.js
@@ -2,7 +2,7 @@
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-var main = function () {
+function main () {
 	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 }
 

--- a/test/bundle/output/cjs/22.js
+++ b/test/bundle/output/cjs/22.js
@@ -4,6 +4,8 @@ function foo () {
 	console.log( 'fooing' );
 }
 
-exports.foo = foo;
 
+// foo
 foo();
+
+exports.foo = foo;

--- a/test/bundle/output/cjs/25.js
+++ b/test/bundle/output/cjs/25.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var foo = function () {
+function foo () {
 	console.log( 'fooing' );
 }
 

--- a/test/bundle/output/cjs/29.js
+++ b/test/bundle/output/cjs/29.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var foo = require('foo');
-var foo__default = ('default' in foo ? foo['default'] : foo);
+var foo__default = 'default' in foo ? foo['default'] : foo;
 
 foo__default();
 foo.bar();

--- a/test/bundle/output/cjs/31.js
+++ b/test/bundle/output/cjs/31.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function someOtherName () {}
+function _x () {}
 
-function x () {}
+function someOtherName () {}
 
 someOtherName();

--- a/test/bundle/output/cjs/33.js
+++ b/test/bundle/output/cjs/33.js
@@ -1,17 +1,15 @@
 'use strict';
 
-var _Promise__Promise = function () {};
-
-_Promise__Promise.prototype = {
-	keep () { this.state = 'kept'; },
-	break () { this.state = 'broken'; }
-};
-
-var _Promise = _Promise__Promise;
-
 var _Math = {
 	get add () { return add; },
 	get multiply () { return multiply; }
+};
+
+var _Promise = function () {};
+
+_Promise.prototype = {
+	keep () { this.state = 'kept'; },
+	break () { this.state = 'broken'; }
 };
 
 function add ( a, b ) {
@@ -33,3 +31,7 @@ var promise = new _Promise();
 promise.keep();
 
 console.log( _Math.add( 40, 2 ) );
+
+foo().then( function ( num ) {
+	console.log( num );
+});

--- a/test/bundle/output/cjs/35.js
+++ b/test/bundle/output/cjs/35.js
@@ -1,9 +1,5 @@
 'use strict';
 
-function a () {
-	console.log( 'I am module a' );
-}
-
 function c () {
 	console.log( 'I am module c' );
 }
@@ -11,6 +7,10 @@ function c () {
 function b () {
 	console.log( 'I am module b' );
 	c();
+}
+
+function a () {
+	console.log( 'I am module a' );
 }
 
 function external () {

--- a/test/bundle/output/cjs/37.js
+++ b/test/bundle/output/cjs/37.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var x = require('moment');
-x = ('default' in x ? x['default'] : x);
+x = 'default' in x ? x['default'] : x;
 
 var a__x = 'wut';
 var a = a__x;

--- a/test/bundle/output/cjs/37.js
+++ b/test/bundle/output/cjs/37.js
@@ -3,6 +3,8 @@
 var x = require('moment');
 x = 'default' in x ? x['default'] : x;
 
-var a__x = 'wut';
-var a = a__x;
+var __x = 'wut';
+var a = __x;
 
+x();
+console.log( a );

--- a/test/bundle/output/cjs/43.js
+++ b/test/bundle/output/cjs/43.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var Bar = require('bar');
-Bar = ('default' in Bar ? Bar['default'] : Bar);
+Bar = 'default' in Bar ? Bar['default'] : Bar;
 
 class Foo extends Bar {
 	constructor() {

--- a/test/bundle/output/cjs/44.js
+++ b/test/bundle/output/cjs/44.js
@@ -1,9 +1,9 @@
 'use strict';
 
 var foo = require('foo');
-foo = ('default' in foo ? foo['default'] : foo);
+foo = 'default' in foo ? foo['default'] : foo;
 var _bar = require('bar');
-_bar = ('default' in _bar ? _bar['default'] : _bar);
+_bar = 'default' in _bar ? _bar['default'] : _bar;
 
 
 

--- a/test/bundle/output/cjs/48.js
+++ b/test/bundle/output/cjs/48.js
@@ -1,6 +1,6 @@
 'use strict';
 
 var external = require('external');
-external = ('default' in external ? external['default'] : external);
+external = 'default' in external ? external['default'] : external;
 
 external();

--- a/test/bundle/output/cjs/51.js
+++ b/test/bundle/output/cjs/51.js
@@ -5,3 +5,4 @@ highlight = 'default' in highlight ? highlight['default'] : highlight;
 
 var foo = 42;
 
+highlight( foo );

--- a/test/bundle/output/cjs/51.js
+++ b/test/bundle/output/cjs/51.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var highlight = require('highlight.js');
-highlight = ('default' in highlight ? highlight['default'] : highlight);
+highlight = 'default' in highlight ? highlight['default'] : highlight;
 
 var foo = 42;
 

--- a/test/bundle/output/cjs/52.js
+++ b/test/bundle/output/cjs/52.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var not_baz = function () {
+function baz () {
 	// baz.js
-};
+}
 
 
-
-console.log( 'baz', not_baz );
-
+// bar.js
+console.log( 'baz', baz );

--- a/test/bundle/output/cjs/53.js
+++ b/test/bundle/output/cjs/53.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var foo = function () {
+function foo () {
 	console.log( 'foo' );
 }
 
 foo();
 
-var main = function () {
+function main () {
 	console.log( 'main' );
 }
 

--- a/test/bundle/output/cjs/54.js
+++ b/test/bundle/output/cjs/54.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var bluebird = require('bluebird');
-bluebird = ('default' in bluebird ? bluebird['default'] : bluebird);
+bluebird = 'default' in bluebird ? bluebird['default'] : bluebird;
 
 var foo = 'foo';
 

--- a/test/bundle/output/cjs/54.js
+++ b/test/bundle/output/cjs/54.js
@@ -1,7 +1,10 @@
 'use strict';
 
-var bluebird = require('bluebird');
-bluebird = 'default' in bluebird ? bluebird['default'] : bluebird;
+var _Promise = require('bluebird');
+_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
 var foo = 'foo';
 
+_Promise.resolve( foo ).then( function ( foo ) {
+	console.log( foo );
+});

--- a/test/bundle/output/cjs/55.js
+++ b/test/bundle/output/cjs/55.js
@@ -10,7 +10,8 @@ class A {
 	}
 }
 
-class B extends A {}
-
 class C extends A {}
 
+class B extends A {}
+
+new A();

--- a/test/bundle/output/cjs/56.js
+++ b/test/bundle/output/cjs/56.js
@@ -6,4 +6,4 @@ foo = 99;
 foo += 1;
 foo++;
 
-console.log( _foo ); // 42
+console.log( _foo );

--- a/test/bundle/output/cjs/58.js
+++ b/test/bundle/output/cjs/58.js
@@ -1,5 +1,3 @@
 'use strict';
 
-var x = 42;
-
-exports.y = x;
+exports.y = 42;

--- a/test/bundle/output/cjs/59.js
+++ b/test/bundle/output/cjs/59.js
@@ -2,4 +2,4 @@
 
 var foo = 'foo';
 
-console.log( foo ); // 'foo'
+console.log( foo );

--- a/test/bundle/output/cjsDefaults/03.js
+++ b/test/bundle/output/cjsDefaults/03.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var external = require('external');
+external = 'default' in external ? external['default'] : external;
 
 var bar = 'yes';
 var foo = bar;

--- a/test/bundle/output/cjsDefaults/06.js
+++ b/test/bundle/output/cjsDefaults/06.js
@@ -1,7 +1,8 @@
 'use strict';
 
 var external = require('utils/external');
+external = 'default' in external ? external['default'] : external;
 
 var message = 'this is a message';
 
-console.log( message );
+console.log( external( message ) );

--- a/test/bundle/output/cjsDefaults/08.js
+++ b/test/bundle/output/cjsDefaults/08.js
@@ -1,3 +1,6 @@
 'use strict';
 
 var ImplicitlyNamed = require('external');
+ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
+
+new ImplicitlyNamed();

--- a/test/bundle/output/cjsDefaults/09.js
+++ b/test/bundle/output/cjsDefaults/09.js
@@ -1,3 +1,6 @@
 'use strict';
 
-var Correct = require('external');
+var ExplicitlyNamed = require('external');
+ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
+
+new ExplicitlyNamed();

--- a/test/bundle/output/cjsDefaults/14.js
+++ b/test/bundle/output/cjsDefaults/14.js
@@ -1,5 +1,6 @@
 'use strict';
 
 var foo = require('external');
+foo = 'default' in foo ? foo['default'] : foo;
 
 foo();

--- a/test/bundle/output/cjsDefaults/15.js
+++ b/test/bundle/output/cjsDefaults/15.js
@@ -1,0 +1,5 @@
+'use strict';
+
+var external = require('external');
+
+external.foo();

--- a/test/bundle/output/cjsDefaults/16.js
+++ b/test/bundle/output/cjsDefaults/16.js
@@ -1,18 +1,19 @@
 'use strict';
 
-function _a__a () {
-	console.log( 'a' );
-}
-
-function c__a () {
+function _a () {
 	console.log( 'a but actually c' );
 }
 
-var b = function () {
+function b () {
 	// a but actually c
-	c__a();
+	_a();
+}
+
+function a () {
+	console.log( 'a' );
 }
 
 function foo () {
-	_a__a();
+	a();
+	b();
 }

--- a/test/bundle/output/cjsDefaults/17.js
+++ b/test/bundle/output/cjsDefaults/17.js
@@ -1,11 +1,11 @@
 'use strict';
 
-function foo__a ( message ) {
+function a ( message ) {
 	console.log( message );
 }
 
-foo__a();
+a();
 (function () {
-	var a = 'c';
-	foo__a( a );
+	var a$$ = 'c';
+	a( a$$ );
 }());

--- a/test/bundle/output/cjsDefaults/18.js
+++ b/test/bundle/output/cjsDefaults/18.js
@@ -1,14 +1,14 @@
 'use strict';
 
-var _doThing = function () {
+function _doThing () {
 	console.log( 'doing foo thing' );
 }
 
-var foo = function () {
+function foo () {
 	_doThing();
 }
 
-var bar = function () {
+function bar () {
 	doThing();
 }
 
@@ -16,3 +16,5 @@ var doThing = function ( item ) {
 	console.log( 'doing bar thing' );
 }
 
+foo();
+bar();

--- a/test/bundle/output/cjsDefaults/20.js
+++ b/test/bundle/output/cjsDefaults/20.js
@@ -2,7 +2,7 @@
 
 var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-var main = function () {
+function main () {
 	console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 }
 

--- a/test/bundle/output/cjsDefaults/25.js
+++ b/test/bundle/output/cjsDefaults/25.js
@@ -1,6 +1,6 @@
 'use strict';
 
-var foo = function () {
+function foo () {
 	console.log( 'fooing' );
 }
 

--- a/test/bundle/output/cjsDefaults/29.js
+++ b/test/bundle/output/cjsDefaults/29.js
@@ -1,0 +1,7 @@
+'use strict';
+
+var foo = require('foo');
+var foo__default = 'default' in foo ? foo['default'] : foo;
+
+foo__default();
+foo.bar();

--- a/test/bundle/output/cjsDefaults/31.js
+++ b/test/bundle/output/cjsDefaults/31.js
@@ -1,7 +1,7 @@
 'use strict';
 
-function someOtherName () {}
+function _x () {}
 
-function x () {}
+function someOtherName () {}
 
 someOtherName();

--- a/test/bundle/output/cjsDefaults/33.js
+++ b/test/bundle/output/cjsDefaults/33.js
@@ -1,17 +1,15 @@
 'use strict';
 
-var _Promise__Promise = function () {};
-
-_Promise__Promise.prototype = {
-	keep () { this.state = 'kept'; },
-	break () { this.state = 'broken'; }
-};
-
-var _Promise = _Promise__Promise;
-
 var _Math = {
 	get add () { return add; },
 	get multiply () { return multiply; }
+};
+
+var _Promise = function () {};
+
+_Promise.prototype = {
+	keep () { this.state = 'kept'; },
+	break () { this.state = 'broken'; }
 };
 
 function add ( a, b ) {
@@ -33,3 +31,7 @@ var promise = new _Promise();
 promise.keep();
 
 console.log( _Math.add( 40, 2 ) );
+
+foo().then( function ( num ) {
+	console.log( num );
+});

--- a/test/bundle/output/cjsDefaults/35.js
+++ b/test/bundle/output/cjsDefaults/35.js
@@ -1,9 +1,5 @@
 'use strict';
 
-function a () {
-	console.log( 'I am module a' );
-}
-
 function c () {
 	console.log( 'I am module c' );
 }
@@ -11,6 +7,10 @@ function c () {
 function b () {
 	console.log( 'I am module b' );
 	c();
+}
+
+function a () {
+	console.log( 'I am module a' );
 }
 
 function external () {

--- a/test/bundle/output/cjsDefaults/37.js
+++ b/test/bundle/output/cjsDefaults/37.js
@@ -1,7 +1,10 @@
 'use strict';
 
 var x = require('moment');
+x = 'default' in x ? x['default'] : x;
 
-var a__x = 'wut';
-var a = a__x;
+var __x = 'wut';
+var a = __x;
 
+x();
+console.log( a );

--- a/test/bundle/output/cjsDefaults/43.js
+++ b/test/bundle/output/cjsDefaults/43.js
@@ -1,6 +1,7 @@
 'use strict';
 
 var Bar = require('bar');
+Bar = 'default' in Bar ? Bar['default'] : Bar;
 
 class Foo extends Bar {
 	constructor() {

--- a/test/bundle/output/cjsDefaults/48.js
+++ b/test/bundle/output/cjsDefaults/48.js
@@ -1,5 +1,6 @@
 'use strict';
 
 var external = require('external');
+external = 'default' in external ? external['default'] : external;
 
 external();

--- a/test/bundle/output/cjsDefaults/51.js
+++ b/test/bundle/output/cjsDefaults/51.js
@@ -1,6 +1,8 @@
 'use strict';
 
 var highlight = require('highlight.js');
+highlight = 'default' in highlight ? highlight['default'] : highlight;
 
 var foo = 42;
 
+highlight( foo );

--- a/test/bundle/output/cjsDefaults/52.js
+++ b/test/bundle/output/cjsDefaults/52.js
@@ -1,10 +1,9 @@
 'use strict';
 
-var not_baz = function () {
+function baz () {
 	// baz.js
-};
+}
 
 
-
-console.log( 'baz', not_baz );
-
+// bar.js
+console.log( 'baz', baz );

--- a/test/bundle/output/cjsDefaults/53.js
+++ b/test/bundle/output/cjsDefaults/53.js
@@ -1,12 +1,12 @@
 'use strict';
 
-var foo = function () {
+function foo () {
 	console.log( 'foo' );
 }
 
 foo();
 
-var main = function () {
+function main () {
 	console.log( 'main' );
 }
 

--- a/test/bundle/output/cjsDefaults/54.js
+++ b/test/bundle/output/cjsDefaults/54.js
@@ -1,6 +1,10 @@
 'use strict';
 
-var bluebird = require('bluebird');
+var _Promise = require('bluebird');
+_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
 var foo = 'foo';
 
+_Promise.resolve( foo ).then( function ( foo ) {
+	console.log( foo );
+});

--- a/test/bundle/output/cjsDefaults/55.js
+++ b/test/bundle/output/cjsDefaults/55.js
@@ -10,7 +10,8 @@ class A {
 	}
 }
 
-class B extends A {}
-
 class C extends A {}
 
+class B extends A {}
+
+new A();

--- a/test/bundle/output/cjsDefaults/56.js
+++ b/test/bundle/output/cjsDefaults/56.js
@@ -6,4 +6,4 @@ foo = 99;
 foo += 1;
 foo++;
 
-console.log( _foo ); // 42
+console.log( _foo );

--- a/test/bundle/output/cjsDefaults/59.js
+++ b/test/bundle/output/cjsDefaults/59.js
@@ -2,4 +2,4 @@
 
 var foo = 'foo';
 
-console.log( foo ); // 'foo'
+console.log( foo );

--- a/test/bundle/output/concat/03.js
+++ b/test/bundle/output/concat/03.js
@@ -1,0 +1,10 @@
+(function (external) { 'use strict';
+
+	external = 'default' in external ? external['default'] : external;
+
+	var bar = 'yes';
+	var foo = bar;
+
+	console.log( external( foo ) );
+
+})(external);

--- a/test/bundle/output/concat/04.js
+++ b/test/bundle/output/concat/04.js
@@ -1,0 +1,9 @@
+var myModule = (function () { 'use strict';
+
+	var answer = 42;
+
+	var main = answer * 2;
+
+	return main;
+
+})();

--- a/test/bundle/output/concat/06.js
+++ b/test/bundle/output/concat/06.js
@@ -1,4 +1,4 @@
-define(['utils/external'], function (external) { 'use strict';
+(function (external) { 'use strict';
 
 	external = 'default' in external ? external['default'] : external;
 
@@ -6,4 +6,4 @@ define(['utils/external'], function (external) { 'use strict';
 
 	console.log( external( message ) );
 
-});
+})(external);

--- a/test/bundle/output/concat/08.js
+++ b/test/bundle/output/concat/08.js
@@ -1,7 +1,7 @@
-define(['external'], function (ImplicitlyNamed) { 'use strict';
+(function (ImplicitlyNamed) { 'use strict';
 
 	ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
 
 	new ImplicitlyNamed();
 
-});
+})(ImplicitlyNamed);

--- a/test/bundle/output/concat/09.js
+++ b/test/bundle/output/concat/09.js
@@ -1,7 +1,7 @@
-define(['external'], function (ExplicitlyNamed) { 'use strict';
+(function (ExplicitlyNamed) { 'use strict';
 
 	ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
 
 	new ExplicitlyNamed();
 
-});
+})(Correct);

--- a/test/bundle/output/concat/10.js
+++ b/test/bundle/output/concat/10.js
@@ -1,0 +1,15 @@
+var myModule = (function () { 'use strict';
+
+	class Foo {
+		constructor( str ) {
+			this.str = str;
+		}
+
+		toString() {
+			return this.str;
+		}
+	}
+
+	return Foo;
+
+})();

--- a/test/bundle/output/concat/14.js
+++ b/test/bundle/output/concat/14.js
@@ -1,7 +1,7 @@
-define(['external'], function (foo) { 'use strict';
+(function (foo) { 'use strict';
 
 	foo = 'default' in foo ? foo['default'] : foo;
 
 	foo();
 
-});
+})(foo);

--- a/test/bundle/output/concat/15.js
+++ b/test/bundle/output/concat/15.js
@@ -1,0 +1,5 @@
+(function (external) { 'use strict';
+
+	external.foo();
+
+})(external);

--- a/test/bundle/output/concat/16.js
+++ b/test/bundle/output/concat/16.js
@@ -1,20 +1,21 @@
 (function () { 'use strict';
 
-	function _a__a () {
-		console.log( 'a' );
-	}
-
-	function c__a () {
+	function _a () {
 		console.log( 'a but actually c' );
 	}
 
-	var b = function () {
+	function b () {
 		// a but actually c
-		c__a();
+		_a();
+	}
+
+	function a () {
+		console.log( 'a' );
 	}
 
 	function foo () {
-		_a__a();
+		a();
+		b();
 	}
 
 })();

--- a/test/bundle/output/concat/17.js
+++ b/test/bundle/output/concat/17.js
@@ -1,13 +1,13 @@
 (function () { 'use strict';
 
-	function foo__a ( message ) {
+	function a ( message ) {
 		console.log( message );
 	}
 
-	foo__a();
+	a();
 	(function () {
-		var a = 'c';
-		foo__a( a );
+		var a$$ = 'c';
+		a( a$$ );
 	}());
 
 })();

--- a/test/bundle/output/concat/18.js
+++ b/test/bundle/output/concat/18.js
@@ -1,14 +1,14 @@
 (function () { 'use strict';
 
-	var _doThing = function () {
+	function _doThing () {
 		console.log( 'doing foo thing' );
 	}
 
-	var foo = function () {
+	function foo () {
 		_doThing();
 	}
 
-	var bar = function () {
+	function bar () {
 		doThing();
 	}
 
@@ -16,6 +16,7 @@
 		console.log( 'doing bar thing' );
 	}
 
-
+	foo();
+	bar();
 
 })();

--- a/test/bundle/output/concat/20.js
+++ b/test/bundle/output/concat/20.js
@@ -1,4 +1,4 @@
-define(['exports'], function (exports) { 'use strict';
+var myModule = (function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
@@ -6,6 +6,6 @@ define(['exports'], function (exports) { 'use strict';
 		console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 	}
 
-	exports['default'] = main;
+	return main;
 
-});
+})();

--- a/test/bundle/output/concat/25.js
+++ b/test/bundle/output/concat/25.js
@@ -1,6 +1,6 @@
 (function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'fooing' );
 	}
 

--- a/test/bundle/output/concat/29.js
+++ b/test/bundle/output/concat/29.js
@@ -1,8 +1,8 @@
-define(['foo'], function (foo) { 'use strict';
+(function (foo) { 'use strict';
 
 	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	foo__default();
 	foo.bar();
 
-});
+})(foo);

--- a/test/bundle/output/concat/30.js
+++ b/test/bundle/output/concat/30.js
@@ -1,0 +1,5 @@
+(function (foo) { 'use strict';
+
+	foo.bar();
+
+})(foo);

--- a/test/bundle/output/concat/31.js
+++ b/test/bundle/output/concat/31.js
@@ -1,8 +1,8 @@
 (function () { 'use strict';
 
-	function someOtherName () {}
+	function _x () {}
 
-	function x () {}
+	function someOtherName () {}
 
 	someOtherName();
 

--- a/test/bundle/output/concat/33.js
+++ b/test/bundle/output/concat/33.js
@@ -1,17 +1,15 @@
 (function () { 'use strict';
 
-	var _Promise__Promise = function () {};
-
-	_Promise__Promise.prototype = {
-		keep () { this.state = 'kept'; },
-		break () { this.state = 'broken'; }
-	};
-
-	var _Promise = _Promise__Promise;
-
 	var _Math = {
 		get add () { return add; },
 		get multiply () { return multiply; }
+	};
+
+	var _Promise = function () {};
+
+	_Promise.prototype = {
+		keep () { this.state = 'kept'; },
+		break () { this.state = 'broken'; }
 	};
 
 	function add ( a, b ) {
@@ -33,5 +31,9 @@
 	promise.keep();
 
 	console.log( _Math.add( 40, 2 ) );
+
+	foo().then( function ( num ) {
+		console.log( num );
+	});
 
 })();

--- a/test/bundle/output/concat/35.js
+++ b/test/bundle/output/concat/35.js
@@ -1,9 +1,5 @@
 (function () { 'use strict';
 
-	function a () {
-		console.log( 'I am module a' );
-	}
-
 	function c () {
 		console.log( 'I am module c' );
 	}
@@ -11,6 +7,10 @@
 	function b () {
 		console.log( 'I am module b' );
 		c();
+	}
+
+	function a () {
+		console.log( 'I am module a' );
 	}
 
 	function external () {

--- a/test/bundle/output/concat/37.js
+++ b/test/bundle/output/concat/37.js
@@ -1,4 +1,4 @@
-define(['moment'], function (x) { 'use strict';
+(function (x) { 'use strict';
 
 	x = 'default' in x ? x['default'] : x;
 
@@ -8,4 +8,4 @@ define(['moment'], function (x) { 'use strict';
 	x();
 	console.log( a );
 
-});
+})(moment);

--- a/test/bundle/output/concat/43.js
+++ b/test/bundle/output/concat/43.js
@@ -1,4 +1,4 @@
-define(['bar'], function (Bar) { 'use strict';
+(function (Bar) { 'use strict';
 
 	Bar = 'default' in Bar ? Bar['default'] : Bar;
 
@@ -9,4 +9,4 @@ define(['bar'], function (Bar) { 'use strict';
 		}
 	}
 
-});
+})(Bar);

--- a/test/bundle/output/concat/47.js
+++ b/test/bundle/output/concat/47.js
@@ -1,4 +1,4 @@
-(function () { 'use strict';
+(function () {
 
 	implicitGlobal = 'lol';
 

--- a/test/bundle/output/concat/48.js
+++ b/test/bundle/output/concat/48.js
@@ -1,7 +1,7 @@
-define(['external'], function (external) { 'use strict';
+(function (external) { 'use strict';
 
 	external = 'default' in external ? external['default'] : external;
 
 	external();
 
-});
+})(external);

--- a/test/bundle/output/concat/51.js
+++ b/test/bundle/output/concat/51.js
@@ -1,4 +1,4 @@
-define(['highlight.js'], function (highlight) { 'use strict';
+(function (highlight) { 'use strict';
 
 	highlight = 'default' in highlight ? highlight['default'] : highlight;
 
@@ -6,4 +6,4 @@ define(['highlight.js'], function (highlight) { 'use strict';
 
 	highlight( foo );
 
-});
+})(highlight);

--- a/test/bundle/output/concat/52.js
+++ b/test/bundle/output/concat/52.js
@@ -1,13 +1,11 @@
 (function () { 'use strict';
 
-	var not_baz = function () {
+	function baz () {
 		// baz.js
-	};
+	}
 
 
-
-	console.log( 'baz', not_baz );
-
-
+	// bar.js
+	console.log( 'baz', baz );
 
 })();

--- a/test/bundle/output/concat/53.js
+++ b/test/bundle/output/concat/53.js
@@ -1,4 +1,4 @@
-define(function () { 'use strict';
+var myModule = (function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );
@@ -12,4 +12,4 @@ define(function () { 'use strict';
 
 	return main;
 
-});
+})();

--- a/test/bundle/output/concat/54.js
+++ b/test/bundle/output/concat/54.js
@@ -1,4 +1,4 @@
-define(['bluebird'], function (_Promise) { 'use strict';
+(function (_Promise) { 'use strict';
 
 	_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
@@ -8,4 +8,4 @@ define(['bluebird'], function (_Promise) { 'use strict';
 		console.log( foo );
 	});
 
-});
+})(Promise);

--- a/test/bundle/output/concat/55.js
+++ b/test/bundle/output/concat/55.js
@@ -10,10 +10,10 @@
 		}
 	}
 
-	class B extends A {}
-
 	class C extends A {}
 
+	class B extends A {}
 
+	new A();
 
 })();

--- a/test/bundle/output/concat/56.js
+++ b/test/bundle/output/concat/56.js
@@ -6,6 +6,6 @@
 	foo += 1;
 	foo++;
 
-	console.log( _foo ); // 42
+	console.log( _foo );
 
 })();

--- a/test/bundle/output/concat/59.js
+++ b/test/bundle/output/concat/59.js
@@ -2,6 +2,6 @@
 
 	var foo = 'foo';
 
-	console.log( foo ); // 'foo'
+	console.log( foo );
 
 })();

--- a/test/bundle/output/umd/01.js
+++ b/test/bundle/output/umd/01.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/umd/02.js
+++ b/test/bundle/output/umd/02.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/umd/03.js
+++ b/test/bundle/output/umd/03.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
 
-	external = ('default' in external ? external['default'] : external);
+	external = 'default' in external ? external['default'] : external;
 
 	var bar = 'yes';
 	var foo = bar;

--- a/test/bundle/output/umd/04.js
+++ b/test/bundle/output/umd/04.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	var answer = 42;

--- a/test/bundle/output/umd/05.js
+++ b/test/bundle/output/umd/05.js
@@ -1,21 +1,17 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	var one = 1;
 	var two = 2;
 	var three = 3;
 
-	var four = one + 3;
-	var five = two + 3;
-	var six = three + 3;
+	exports.four = one + 3;
+	exports.five = two + 3;
+	exports.six = three + 3;
 
-	four = 99;
-
-	exports.four = four;
-	exports.five = five;
-	exports.six = six;
+	exports.four = 99;
 
 }));

--- a/test/bundle/output/umd/06.js
+++ b/test/bundle/output/umd/06.js
@@ -1,13 +1,13 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('utils/external')) :
 	typeof define === 'function' && define.amd ? define(['utils/external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
 
-	external = ('default' in external ? external['default'] : external);
+	external = 'default' in external ? external['default'] : external;
 
 	var message = 'this is a message';
 
-	console.log( message );
+	console.log( external( message ) );
 
 }));

--- a/test/bundle/output/umd/07.js
+++ b/test/bundle/output/umd/07.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 'this is foo';
 

--- a/test/bundle/output/umd/09.js
+++ b/test/bundle/output/umd/09.js
@@ -2,8 +2,10 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
 	factory(global.Correct);
-}(this, function (Correct) { 'use strict';
+}(this, function (ExplicitlyNamed) { 'use strict';
 
-	Correct = 'default' in Correct ? Correct['default'] : Correct;
+	ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
+
+	new ExplicitlyNamed();
 
 }));

--- a/test/bundle/output/umd/09.js
+++ b/test/bundle/output/umd/09.js
@@ -1,9 +1,9 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.Correct)
+	factory(global.Correct);
 }(this, function (Correct) { 'use strict';
 
-	Correct = ('default' in Correct ? Correct['default'] : Correct);
+	Correct = 'default' in Correct ? Correct['default'] : Correct;
 
 }));

--- a/test/bundle/output/umd/10.js
+++ b/test/bundle/output/umd/10.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	class Foo {

--- a/test/bundle/output/umd/11.js
+++ b/test/bundle/output/umd/11.js
@@ -1,24 +1,19 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
-
-	var foo = 1;
-	var bar = 2;
-
-	foo = 3;
-
-	exports.foo = foo;
-	exports.bar = bar;
 
 	var baz = 4;
 
+	exports.foo = 1;
+	exports.bar = 2;
+
+	exports.foo = 3;
+
+	exports.qux = 5;
+	exports.qux = 6;
+
 	exports.baz = baz;
-
-	var qux = 5;
-	qux = 6;
-
-	exports.qux = qux;
 
 }));

--- a/test/bundle/output/umd/14.js
+++ b/test/bundle/output/umd/14.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.foo)
+	factory(global.foo);
 }(this, function (foo) { 'use strict';
 
-	foo = ('default' in foo ? foo['default'] : foo);
+	foo = 'default' in foo ? foo['default'] : foo;
 
 	foo();
 

--- a/test/bundle/output/umd/15.js
+++ b/test/bundle/output/umd/15.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
 
 	external.foo();

--- a/test/bundle/output/umd/16.js
+++ b/test/bundle/output/umd/16.js
@@ -4,21 +4,22 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function _a__a () {
-		console.log( 'a' );
-	}
-
-	function c__a () {
+	function _a () {
 		console.log( 'a but actually c' );
 	}
 
-	var b = function () {
+	function b () {
 		// a but actually c
-		c__a();
+		_a();
+	}
+
+	function a () {
+		console.log( 'a' );
 	}
 
 	function foo () {
-		_a__a();
+		a();
+		b();
 	}
 
 }));

--- a/test/bundle/output/umd/16.js
+++ b/test/bundle/output/umd/16.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function _a__a () {
 		console.log( 'a' );

--- a/test/bundle/output/umd/17.js
+++ b/test/bundle/output/umd/17.js
@@ -4,14 +4,14 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function foo__a ( message ) {
+	function a ( message ) {
 		console.log( message );
 	}
 
-	foo__a();
+	a();
 	(function () {
-		var a = 'c';
-		foo__a( a );
+		var a$$ = 'c';
+		a( a$$ );
 	}());
 
 }));

--- a/test/bundle/output/umd/17.js
+++ b/test/bundle/output/umd/17.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo__a ( message ) {
 		console.log( message );

--- a/test/bundle/output/umd/18.js
+++ b/test/bundle/output/umd/18.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _doThing = function () {
 		console.log( 'doing foo thing' );

--- a/test/bundle/output/umd/18.js
+++ b/test/bundle/output/umd/18.js
@@ -4,15 +4,15 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var _doThing = function () {
+	function _doThing () {
 		console.log( 'doing foo thing' );
 	}
 
-	var foo = function () {
+	function foo () {
 		_doThing();
 	}
 
-	var bar = function () {
+	function bar () {
 		doThing();
 	}
 
@@ -20,6 +20,7 @@
 		console.log( 'doing bar thing' );
 	}
 
-
+	foo();
+	bar();
 
 }));

--- a/test/bundle/output/umd/19.js
+++ b/test/bundle/output/umd/19.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/umd/20.js
+++ b/test/bundle/output/umd/20.js
@@ -1,12 +1,12 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-	var main = function () {
+	function main () {
 		console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 	}
 

--- a/test/bundle/output/umd/21.js
+++ b/test/bundle/output/umd/21.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	const config = {};
 

--- a/test/bundle/output/umd/22.js
+++ b/test/bundle/output/umd/22.js
@@ -1,15 +1,17 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );
 	}
 
-	exports.foo = foo;
 
+	// foo
 	foo();
+
+	exports.foo = foo;
 
 }));

--- a/test/bundle/output/umd/24.js
+++ b/test/bundle/output/umd/24.js
@@ -1,9 +1,9 @@
 /* this is a banner */
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/bundle/output/umd/25.js
+++ b/test/bundle/output/umd/25.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define('myModule', factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = function () {
 		console.log( 'fooing' );

--- a/test/bundle/output/umd/25.js
+++ b/test/bundle/output/umd/25.js
@@ -4,7 +4,7 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'fooing' );
 	}
 

--- a/test/bundle/output/umd/26.js
+++ b/test/bundle/output/umd/26.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function bar () {
 		console.log( 'baring' );

--- a/test/bundle/output/umd/27.js
+++ b/test/bundle/output/umd/27.js
@@ -1,8 +1,8 @@
-(function (factory) {
-  !(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  factory()
-}(function () { 'use strict';
+  factory();
+}(this, function () { 'use strict';
 
   var foo = 'this is foo';
 

--- a/test/bundle/output/umd/28.js
+++ b/test/bundle/output/umd/28.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = () => undefined;
 

--- a/test/bundle/output/umd/29.js
+++ b/test/bundle/output/umd/29.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	factory(global.foo)
+	factory(global.foo);
 }(this, function (foo) { 'use strict';
 
-	var foo__default = ('default' in foo ? foo['default'] : foo);
+	var foo__default = 'default' in foo ? foo['default'] : foo;
 
 	foo__default();
 	foo.bar();

--- a/test/bundle/output/umd/30.js
+++ b/test/bundle/output/umd/30.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	factory(global.foo)
+	factory(global.foo);
 }(this, function (foo) { 'use strict';
 
 	foo.bar();

--- a/test/bundle/output/umd/31.js
+++ b/test/bundle/output/umd/31.js
@@ -4,9 +4,9 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function someOtherName () {}
+	function _x () {}
 
-	function x () {}
+	function someOtherName () {}
 
 	someOtherName();
 

--- a/test/bundle/output/umd/31.js
+++ b/test/bundle/output/umd/31.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function someOtherName () {}
 

--- a/test/bundle/output/umd/32.js
+++ b/test/bundle/output/umd/32.js
@@ -1,7 +1,7 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 }));

--- a/test/bundle/output/umd/32.js
+++ b/test/bundle/output/umd/32.js
@@ -4,4 +4,6 @@
 	factory();
 }(this, function () { 'use strict';
 
+
+
 }));

--- a/test/bundle/output/umd/33.js
+++ b/test/bundle/output/umd/33.js
@@ -4,18 +4,16 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var _Promise__Promise = function () {};
-
-	_Promise__Promise.prototype = {
-		keep () { this.state = 'kept'; },
-		break () { this.state = 'broken'; }
-	};
-
-	var _Promise = _Promise__Promise;
-
 	var _Math = {
 		get add () { return add; },
 		get multiply () { return multiply; }
+	};
+
+	var _Promise = function () {};
+
+	_Promise.prototype = {
+		keep () { this.state = 'kept'; },
+		break () { this.state = 'broken'; }
 	};
 
 	function add ( a, b ) {
@@ -37,5 +35,9 @@
 	promise.keep();
 
 	console.log( _Math.add( 40, 2 ) );
+
+	foo().then( function ( num ) {
+		console.log( num );
+	});
 
 }));

--- a/test/bundle/output/umd/33.js
+++ b/test/bundle/output/umd/33.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _Promise__Promise = function () {};
 

--- a/test/bundle/output/umd/34.js
+++ b/test/bundle/output/umd/34.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
 	var foo__exports = {};

--- a/test/bundle/output/umd/35.js
+++ b/test/bundle/output/umd/35.js
@@ -4,10 +4,6 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function a () {
-		console.log( 'I am module a' );
-	}
-
 	function c () {
 		console.log( 'I am module c' );
 	}
@@ -15,6 +11,10 @@
 	function b () {
 		console.log( 'I am module b' );
 		c();
+	}
+
+	function a () {
+		console.log( 'I am module a' );
 	}
 
 	function external () {

--- a/test/bundle/output/umd/35.js
+++ b/test/bundle/output/umd/35.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function a () {
 		console.log( 'I am module a' );

--- a/test/bundle/output/umd/36.js
+++ b/test/bundle/output/umd/36.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function dependsOnExternal () {
 		console.log( external.message );

--- a/test/bundle/output/umd/37.js
+++ b/test/bundle/output/umd/37.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.x)
+	factory(global.x);
 }(this, function (x) { 'use strict';
 
-	x = ('default' in x ? x['default'] : x);
+	x = 'default' in x ? x['default'] : x;
 
 	var a__x = 'wut';
 	var a = a__x;

--- a/test/bundle/output/umd/37.js
+++ b/test/bundle/output/umd/37.js
@@ -1,14 +1,15 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.x);
+	factory(global.moment);
 }(this, function (x) { 'use strict';
 
 	x = 'default' in x ? x['default'] : x;
 
-	var a__x = 'wut';
-	var a = a__x;
+	var __x = 'wut';
+	var a = __x;
 
-
+	x();
+	console.log( a );
 
 }));

--- a/test/bundle/output/umd/38.js
+++ b/test/bundle/output/umd/38.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _foo = notActuallyFoo;
 

--- a/test/bundle/output/umd/40.js
+++ b/test/bundle/output/umd/40.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umd/42.js
+++ b/test/bundle/output/umd/42.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umd/43.js
+++ b/test/bundle/output/umd/43.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bar')) :
 	typeof define === 'function' && define.amd ? define(['bar'], factory) :
-	factory(global.Bar)
+	factory(global.Bar);
 }(this, function (Bar) { 'use strict';
 
-	Bar = ('default' in Bar ? Bar['default'] : Bar);
+	Bar = 'default' in Bar ? Bar['default'] : Bar;
 
 	class Foo extends Bar {
 		constructor() {

--- a/test/bundle/output/umd/44.js
+++ b/test/bundle/output/umd/44.js
@@ -1,11 +1,11 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('bar')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'bar'], factory) :
-	factory(global.foo, global._bar)
+	factory(global.foo, global._bar);
 }(this, function (foo, _bar) { 'use strict';
 
-	foo = ('default' in foo ? foo['default'] : foo);
-	_bar = ('default' in _bar ? _bar['default'] : _bar);
+	foo = 'default' in foo ? foo['default'] : foo;
+	_bar = 'default' in _bar ? _bar['default'] : _bar;
 
 
 

--- a/test/bundle/output/umd/45.js
+++ b/test/bundle/output/umd/45.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/umd/46.js
+++ b/test/bundle/output/umd/46.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/umd/47.js
+++ b/test/bundle/output/umd/47.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () {
+	factory();
+}(this, function () {
 
 	implicitGlobal = 'lol';
 

--- a/test/bundle/output/umd/48.js
+++ b/test/bundle/output/umd/48.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
 
-	external = ('default' in external ? external['default'] : external);
+	external = 'default' in external ? external['default'] : external;
 
 	external();
 

--- a/test/bundle/output/umd/49.js
+++ b/test/bundle/output/umd/49.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umd/50.js
+++ b/test/bundle/output/umd/50.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	class A {
 		constructor () {

--- a/test/bundle/output/umd/51.js
+++ b/test/bundle/output/umd/51.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('highlight.js')) :
 	typeof define === 'function' && define.amd ? define(['highlight.js'], factory) :
-	factory(global.highlight)
+	factory(global.highlight);
 }(this, function (highlight) { 'use strict';
 
-	highlight = ('default' in highlight ? highlight['default'] : highlight);
+	highlight = 'default' in highlight ? highlight['default'] : highlight;
 
 	var foo = 42;
 

--- a/test/bundle/output/umd/51.js
+++ b/test/bundle/output/umd/51.js
@@ -8,6 +8,6 @@
 
 	var foo = 42;
 
-
+	highlight( foo );
 
 }));

--- a/test/bundle/output/umd/52.js
+++ b/test/bundle/output/umd/52.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var not_baz = function () {
 		// baz.js

--- a/test/bundle/output/umd/52.js
+++ b/test/bundle/output/umd/52.js
@@ -4,14 +4,12 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var not_baz = function () {
+	function baz () {
 		// baz.js
-	};
+	}
 
 
-
-	console.log( 'baz', not_baz );
-
-
+	// bar.js
+	console.log( 'baz', baz );
 
 }));

--- a/test/bundle/output/umd/53.js
+++ b/test/bundle/output/umd/53.js
@@ -1,16 +1,16 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'foo' );
 	}
 
 	foo();
 
-	var main = function () {
+	function main () {
 		console.log( 'main' );
 	}
 

--- a/test/bundle/output/umd/54.js
+++ b/test/bundle/output/umd/54.js
@@ -1,13 +1,15 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bluebird')) :
 	typeof define === 'function' && define.amd ? define(['bluebird'], factory) :
-	factory(global.bluebird);
-}(this, function (bluebird) { 'use strict';
+	factory(global.Promise);
+}(this, function (_Promise) { 'use strict';
 
-	bluebird = 'default' in bluebird ? bluebird['default'] : bluebird;
+	_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
 	var foo = 'foo';
 
-
+	_Promise.resolve( foo ).then( function ( foo ) {
+		console.log( foo );
+	});
 
 }));

--- a/test/bundle/output/umd/54.js
+++ b/test/bundle/output/umd/54.js
@@ -1,10 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bluebird')) :
 	typeof define === 'function' && define.amd ? define(['bluebird'], factory) :
-	factory(global.bluebird)
+	factory(global.bluebird);
 }(this, function (bluebird) { 'use strict';
 
-	bluebird = ('default' in bluebird ? bluebird['default'] : bluebird);
+	bluebird = 'default' in bluebird ? bluebird['default'] : bluebird;
 
 	var foo = 'foo';
 

--- a/test/bundle/output/umd/55.js
+++ b/test/bundle/output/umd/55.js
@@ -14,10 +14,10 @@
 		}
 	}
 
-	class B extends A {}
-
 	class C extends A {}
 
+	class B extends A {}
 
+	new A();
 
 }));

--- a/test/bundle/output/umd/55.js
+++ b/test/bundle/output/umd/55.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	class A {
 		b () {

--- a/test/bundle/output/umd/56.js
+++ b/test/bundle/output/umd/56.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 42;
 	var _foo = foo;

--- a/test/bundle/output/umd/56.js
+++ b/test/bundle/output/umd/56.js
@@ -10,6 +10,6 @@
 	foo += 1;
 	foo++;
 
-	console.log( _foo ); // 42
+	console.log( _foo );
 
 }));

--- a/test/bundle/output/umd/57.js
+++ b/test/bundle/output/umd/57.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = {
 		get y () { return x; }

--- a/test/bundle/output/umd/58.js
+++ b/test/bundle/output/umd/58.js
@@ -1,11 +1,9 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(exports) :
 	typeof define === 'function' && define.amd ? define(['exports'], factory) :
-	factory((global.myModule = {}))
+	factory((global.myModule = {}));
 }(this, function (exports) { 'use strict';
 
-	var x = 42;
-
-	exports.y = x;
+	exports.y = 42;
 
 }));

--- a/test/bundle/output/umd/59.js
+++ b/test/bundle/output/umd/59.js
@@ -6,6 +6,6 @@
 
 	var foo = 'foo';
 
-	console.log( foo ); // 'foo'
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umd/59.js
+++ b/test/bundle/output/umd/59.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 'foo';
 

--- a/test/bundle/output/umdDefaults/01.js
+++ b/test/bundle/output/umdDefaults/01.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/umdDefaults/02.js
+++ b/test/bundle/output/umdDefaults/02.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var message = 'yes';
 	var foo = message;

--- a/test/bundle/output/umdDefaults/03.js
+++ b/test/bundle/output/umdDefaults/03.js
@@ -1,8 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
+
+	external = 'default' in external ? external['default'] : external;
 
 	var bar = 'yes';
 	var foo = bar;

--- a/test/bundle/output/umdDefaults/04.js
+++ b/test/bundle/output/umdDefaults/04.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myModule = factory();
 }(this, function () { 'use strict';

--- a/test/bundle/output/umdDefaults/04.js
+++ b/test/bundle/output/umdDefaults/04.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myModule = factory()
+	global.myModule = factory();
 }(this, function () { 'use strict';
 
 	var answer = 42;

--- a/test/bundle/output/umdDefaults/06.js
+++ b/test/bundle/output/umdDefaults/06.js
@@ -1,11 +1,13 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('utils/external')) :
 	typeof define === 'function' && define.amd ? define(['utils/external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
+
+	external = 'default' in external ? external['default'] : external;
 
 	var message = 'this is a message';
 
-	console.log( message );
+	console.log( external( message ) );
 
 }));

--- a/test/bundle/output/umdDefaults/07.js
+++ b/test/bundle/output/umdDefaults/07.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 'this is foo';
 

--- a/test/bundle/output/umdDefaults/08.js
+++ b/test/bundle/output/umdDefaults/08.js
@@ -1,7 +1,11 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.ImplicitlyNamed)
+	factory(global.ImplicitlyNamed);
 }(this, function (ImplicitlyNamed) { 'use strict';
+
+	ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
+
+	new ImplicitlyNamed();
 
 }));

--- a/test/bundle/output/umdDefaults/09.js
+++ b/test/bundle/output/umdDefaults/09.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.Correct)
+	factory(global.Correct);
 }(this, function (Correct) { 'use strict';
 
 }));

--- a/test/bundle/output/umdDefaults/09.js
+++ b/test/bundle/output/umdDefaults/09.js
@@ -2,6 +2,10 @@
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
 	factory(global.Correct);
-}(this, function (Correct) { 'use strict';
+}(this, function (ExplicitlyNamed) { 'use strict';
+
+	ExplicitlyNamed = 'default' in ExplicitlyNamed ? ExplicitlyNamed['default'] : ExplicitlyNamed;
+
+	new ExplicitlyNamed();
 
 }));

--- a/test/bundle/output/umdDefaults/10.js
+++ b/test/bundle/output/umdDefaults/10.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myModule = factory();
 }(this, function () { 'use strict';

--- a/test/bundle/output/umdDefaults/10.js
+++ b/test/bundle/output/umdDefaults/10.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myModule = factory()
+	global.myModule = factory();
 }(this, function () { 'use strict';
 
 	class Foo {

--- a/test/bundle/output/umdDefaults/14.js
+++ b/test/bundle/output/umdDefaults/14.js
@@ -1,8 +1,10 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.foo)
+	factory(global.foo);
 }(this, function (foo) { 'use strict';
+
+	foo = 'default' in foo ? foo['default'] : foo;
 
 	foo();
 

--- a/test/bundle/output/umdDefaults/15.js
+++ b/test/bundle/output/umdDefaults/15.js
@@ -1,11 +1,9 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.ImplicitlyNamed);
-}(this, function (ImplicitlyNamed) { 'use strict';
+	factory(global.external);
+}(this, function (external) { 'use strict';
 
-	ImplicitlyNamed = 'default' in ImplicitlyNamed ? ImplicitlyNamed['default'] : ImplicitlyNamed;
-
-	new ImplicitlyNamed();
+	external.foo();
 
 }));

--- a/test/bundle/output/umdDefaults/16.js
+++ b/test/bundle/output/umdDefaults/16.js
@@ -4,21 +4,22 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function _a__a () {
-		console.log( 'a' );
-	}
-
-	function c__a () {
+	function _a () {
 		console.log( 'a but actually c' );
 	}
 
-	var b = function () {
+	function b () {
 		// a but actually c
-		c__a();
+		_a();
+	}
+
+	function a () {
+		console.log( 'a' );
 	}
 
 	function foo () {
-		_a__a();
+		a();
+		b();
 	}
 
 }));

--- a/test/bundle/output/umdDefaults/16.js
+++ b/test/bundle/output/umdDefaults/16.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function _a__a () {
 		console.log( 'a' );

--- a/test/bundle/output/umdDefaults/17.js
+++ b/test/bundle/output/umdDefaults/17.js
@@ -4,14 +4,14 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function foo__a ( message ) {
+	function a ( message ) {
 		console.log( message );
 	}
 
-	foo__a();
+	a();
 	(function () {
-		var a = 'c';
-		foo__a( a );
+		var a$$ = 'c';
+		a( a$$ );
 	}());
 
 }));

--- a/test/bundle/output/umdDefaults/17.js
+++ b/test/bundle/output/umdDefaults/17.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo__a ( message ) {
 		console.log( message );

--- a/test/bundle/output/umdDefaults/18.js
+++ b/test/bundle/output/umdDefaults/18.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _doThing = function () {
 		console.log( 'doing foo thing' );

--- a/test/bundle/output/umdDefaults/18.js
+++ b/test/bundle/output/umdDefaults/18.js
@@ -4,15 +4,15 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var _doThing = function () {
+	function _doThing () {
 		console.log( 'doing foo thing' );
 	}
 
-	var foo = function () {
+	function foo () {
 		_doThing();
 	}
 
-	var bar = function () {
+	function bar () {
 		doThing();
 	}
 
@@ -20,6 +20,7 @@
 		console.log( 'doing bar thing' );
 	}
 
-
+	foo();
+	bar();
 
 }));

--- a/test/bundle/output/umdDefaults/19.js
+++ b/test/bundle/output/umdDefaults/19.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 

--- a/test/bundle/output/umdDefaults/20.js
+++ b/test/bundle/output/umdDefaults/20.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myModule = factory();
 }(this, function () { 'use strict';

--- a/test/bundle/output/umdDefaults/20.js
+++ b/test/bundle/output/umdDefaults/20.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myModule = factory()
+	global.myModule = factory();
 }(this, function () { 'use strict';
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;

--- a/test/bundle/output/umdDefaults/20.js
+++ b/test/bundle/output/umdDefaults/20.js
@@ -6,7 +6,7 @@
 
 	var hasOwnProperty = Object.prototype.hasOwnProperty;
 
-	var main = function () {
+	function main () {
 		console.log( hasOwnProperty.call({ foo: 'bar' }, 'foo' ) );
 	}
 

--- a/test/bundle/output/umdDefaults/21.js
+++ b/test/bundle/output/umdDefaults/21.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	const config = {};
 

--- a/test/bundle/output/umdDefaults/24.js
+++ b/test/bundle/output/umdDefaults/24.js
@@ -1,9 +1,9 @@
 /* this is a banner */
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'fooing' );

--- a/test/bundle/output/umdDefaults/25.js
+++ b/test/bundle/output/umdDefaults/25.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define('myModule', factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = function () {
 		console.log( 'fooing' );

--- a/test/bundle/output/umdDefaults/25.js
+++ b/test/bundle/output/umdDefaults/25.js
@@ -4,7 +4,7 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'fooing' );
 	}
 

--- a/test/bundle/output/umdDefaults/26.js
+++ b/test/bundle/output/umdDefaults/26.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function bar () {
 		console.log( 'baring' );

--- a/test/bundle/output/umdDefaults/27.js
+++ b/test/bundle/output/umdDefaults/27.js
@@ -1,8 +1,8 @@
-(function (factory) {
-  !(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+  typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
   typeof define === 'function' && define.amd ? define(factory) :
-  factory()
-}(function () { 'use strict';
+  factory();
+}(this, function () { 'use strict';
 
   var foo = 'this is foo';
 

--- a/test/bundle/output/umdDefaults/28.js
+++ b/test/bundle/output/umdDefaults/28.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = () => undefined;
 

--- a/test/bundle/output/umdDefaults/29.js
+++ b/test/bundle/output/umdDefaults/29.js
@@ -1,0 +1,12 @@
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
+	typeof define === 'function' && define.amd ? define(['foo'], factory) :
+	factory(global.foo);
+}(this, function (foo) { 'use strict';
+
+	var foo__default = 'default' in foo ? foo['default'] : foo;
+
+	foo__default();
+	foo.bar();
+
+}));

--- a/test/bundle/output/umdDefaults/30.js
+++ b/test/bundle/output/umdDefaults/30.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo')) :
 	typeof define === 'function' && define.amd ? define(['foo'], factory) :
-	factory(global.foo)
+	factory(global.foo);
 }(this, function (foo) { 'use strict';
 
 	foo.bar();

--- a/test/bundle/output/umdDefaults/31.js
+++ b/test/bundle/output/umdDefaults/31.js
@@ -4,9 +4,9 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function someOtherName () {}
+	function _x () {}
 
-	function x () {}
+	function someOtherName () {}
 
 	someOtherName();
 

--- a/test/bundle/output/umdDefaults/31.js
+++ b/test/bundle/output/umdDefaults/31.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function someOtherName () {}
 

--- a/test/bundle/output/umdDefaults/32.js
+++ b/test/bundle/output/umdDefaults/32.js
@@ -1,7 +1,7 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 }));

--- a/test/bundle/output/umdDefaults/32.js
+++ b/test/bundle/output/umdDefaults/32.js
@@ -4,4 +4,6 @@
 	factory();
 }(this, function () { 'use strict';
 
+
+
 }));

--- a/test/bundle/output/umdDefaults/33.js
+++ b/test/bundle/output/umdDefaults/33.js
@@ -4,18 +4,16 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var _Promise__Promise = function () {};
-
-	_Promise__Promise.prototype = {
-		keep () { this.state = 'kept'; },
-		break () { this.state = 'broken'; }
-	};
-
-	var _Promise = _Promise__Promise;
-
 	var _Math = {
 		get add () { return add; },
 		get multiply () { return multiply; }
+	};
+
+	var _Promise = function () {};
+
+	_Promise.prototype = {
+		keep () { this.state = 'kept'; },
+		break () { this.state = 'broken'; }
 	};
 
 	function add ( a, b ) {
@@ -37,5 +35,9 @@
 	promise.keep();
 
 	console.log( _Math.add( 40, 2 ) );
+
+	foo().then( function ( num ) {
+		console.log( num );
+	});
 
 }));

--- a/test/bundle/output/umdDefaults/33.js
+++ b/test/bundle/output/umdDefaults/33.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _Promise__Promise = function () {};
 

--- a/test/bundle/output/umdDefaults/34.js
+++ b/test/bundle/output/umdDefaults/34.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myModule = factory();
 }(this, function () { 'use strict';

--- a/test/bundle/output/umdDefaults/34.js
+++ b/test/bundle/output/umdDefaults/34.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myModule = factory()
+	global.myModule = factory();
 }(this, function () { 'use strict';
 
 	var foo__exports = {};

--- a/test/bundle/output/umdDefaults/35.js
+++ b/test/bundle/output/umdDefaults/35.js
@@ -4,10 +4,6 @@
 	factory();
 }(this, function () { 'use strict';
 
-	function a () {
-		console.log( 'I am module a' );
-	}
-
 	function c () {
 		console.log( 'I am module c' );
 	}
@@ -15,6 +11,10 @@
 	function b () {
 		console.log( 'I am module b' );
 		c();
+	}
+
+	function a () {
+		console.log( 'I am module a' );
 	}
 
 	function external () {

--- a/test/bundle/output/umdDefaults/35.js
+++ b/test/bundle/output/umdDefaults/35.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function a () {
 		console.log( 'I am module a' );

--- a/test/bundle/output/umdDefaults/36.js
+++ b/test/bundle/output/umdDefaults/36.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function dependsOnExternal () {
 		console.log( external.message );

--- a/test/bundle/output/umdDefaults/37.js
+++ b/test/bundle/output/umdDefaults/37.js
@@ -1,12 +1,15 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.x);
+	factory(global.moment);
 }(this, function (x) { 'use strict';
 
-	var a__x = 'wut';
-	var a = a__x;
+	x = 'default' in x ? x['default'] : x;
 
+	var __x = 'wut';
+	var a = __x;
 
+	x();
+	console.log( a );
 
 }));

--- a/test/bundle/output/umdDefaults/37.js
+++ b/test/bundle/output/umdDefaults/37.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('moment')) :
 	typeof define === 'function' && define.amd ? define(['moment'], factory) :
-	factory(global.x)
+	factory(global.x);
 }(this, function (x) { 'use strict';
 
 	var a__x = 'wut';

--- a/test/bundle/output/umdDefaults/38.js
+++ b/test/bundle/output/umdDefaults/38.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var _foo = notActuallyFoo;
 

--- a/test/bundle/output/umdDefaults/40.js
+++ b/test/bundle/output/umdDefaults/40.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umdDefaults/42.js
+++ b/test/bundle/output/umdDefaults/42.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umdDefaults/43.js
+++ b/test/bundle/output/umdDefaults/43.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bar')) :
 	typeof define === 'function' && define.amd ? define(['bar'], factory) :
-	factory(global.Bar)
+	factory(global.Bar);
 }(this, function (Bar) { 'use strict';
 
 	class Foo extends Bar {

--- a/test/bundle/output/umdDefaults/43.js
+++ b/test/bundle/output/umdDefaults/43.js
@@ -4,6 +4,8 @@
 	factory(global.Bar);
 }(this, function (Bar) { 'use strict';
 
+	Bar = 'default' in Bar ? Bar['default'] : Bar;
+
 	class Foo extends Bar {
 		constructor() {
 			super();

--- a/test/bundle/output/umdDefaults/44.js
+++ b/test/bundle/output/umdDefaults/44.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('foo'), require('bar')) :
 	typeof define === 'function' && define.amd ? define(['foo', 'bar'], factory) :
-	factory(global.foo, global._bar)
+	factory(global.foo, global._bar);
 }(this, function (foo, _bar) { 'use strict';
 
 

--- a/test/bundle/output/umdDefaults/45.js
+++ b/test/bundle/output/umdDefaults/45.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/umdDefaults/46.js
+++ b/test/bundle/output/umdDefaults/46.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var bar = 42;
 

--- a/test/bundle/output/umdDefaults/47.js
+++ b/test/bundle/output/umdDefaults/47.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () {
+	factory();
+}(this, function () {
 
 	implicitGlobal = 'lol';
 

--- a/test/bundle/output/umdDefaults/48.js
+++ b/test/bundle/output/umdDefaults/48.js
@@ -4,6 +4,8 @@
 	factory(global.external);
 }(this, function (external) { 'use strict';
 
+	external = 'default' in external ? external['default'] : external;
+
 	external();
 
 }));

--- a/test/bundle/output/umdDefaults/48.js
+++ b/test/bundle/output/umdDefaults/48.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('external')) :
 	typeof define === 'function' && define.amd ? define(['external'], factory) :
-	factory(global.external)
+	factory(global.external);
 }(this, function (external) { 'use strict';
 
 	external();

--- a/test/bundle/output/umdDefaults/49.js
+++ b/test/bundle/output/umdDefaults/49.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	function foo () {
 		console.log( 'foo' );

--- a/test/bundle/output/umdDefaults/50.js
+++ b/test/bundle/output/umdDefaults/50.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	class A {
 		constructor () {

--- a/test/bundle/output/umdDefaults/51.js
+++ b/test/bundle/output/umdDefaults/51.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('highlight.js')) :
 	typeof define === 'function' && define.amd ? define(['highlight.js'], factory) :
-	factory(global.highlight)
+	factory(global.highlight);
 }(this, function (highlight) { 'use strict';
 
 	var foo = 42;

--- a/test/bundle/output/umdDefaults/51.js
+++ b/test/bundle/output/umdDefaults/51.js
@@ -4,8 +4,10 @@
 	factory(global.highlight);
 }(this, function (highlight) { 'use strict';
 
+	highlight = 'default' in highlight ? highlight['default'] : highlight;
+
 	var foo = 42;
 
-
+	highlight( foo );
 
 }));

--- a/test/bundle/output/umdDefaults/52.js
+++ b/test/bundle/output/umdDefaults/52.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var not_baz = function () {
 		// baz.js

--- a/test/bundle/output/umdDefaults/52.js
+++ b/test/bundle/output/umdDefaults/52.js
@@ -4,14 +4,12 @@
 	factory();
 }(this, function () { 'use strict';
 
-	var not_baz = function () {
+	function baz () {
 		// baz.js
-	};
+	}
 
 
-
-	console.log( 'baz', not_baz );
-
-
+	// bar.js
+	console.log( 'baz', baz );
 
 }));

--- a/test/bundle/output/umdDefaults/53.js
+++ b/test/bundle/output/umdDefaults/53.js
@@ -1,5 +1,5 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
 	global.myModule = factory();
 }(this, function () { 'use strict';

--- a/test/bundle/output/umdDefaults/53.js
+++ b/test/bundle/output/umdDefaults/53.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
-	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory() :
+	typeof exports === 'object' && typeof module !== 'undefined' ? module.exports = factory(); :
 	typeof define === 'function' && define.amd ? define(factory) :
-	global.myModule = factory()
+	global.myModule = factory();
 }(this, function () { 'use strict';
 
 	var foo = function () {

--- a/test/bundle/output/umdDefaults/53.js
+++ b/test/bundle/output/umdDefaults/53.js
@@ -4,13 +4,13 @@
 	global.myModule = factory();
 }(this, function () { 'use strict';
 
-	var foo = function () {
+	function foo () {
 		console.log( 'foo' );
 	}
 
 	foo();
 
-	var main = function () {
+	function main () {
 		console.log( 'main' );
 	}
 

--- a/test/bundle/output/umdDefaults/54.js
+++ b/test/bundle/output/umdDefaults/54.js
@@ -1,7 +1,7 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bluebird')) :
 	typeof define === 'function' && define.amd ? define(['bluebird'], factory) :
-	factory(global.bluebird)
+	factory(global.bluebird);
 }(this, function (bluebird) { 'use strict';
 
 	var foo = 'foo';

--- a/test/bundle/output/umdDefaults/54.js
+++ b/test/bundle/output/umdDefaults/54.js
@@ -1,11 +1,15 @@
 (function (global, factory) {
 	typeof exports === 'object' && typeof module !== 'undefined' ? factory(require('bluebird')) :
 	typeof define === 'function' && define.amd ? define(['bluebird'], factory) :
-	factory(global.bluebird);
-}(this, function (bluebird) { 'use strict';
+	factory(global.Promise);
+}(this, function (_Promise) { 'use strict';
+
+	_Promise = 'default' in _Promise ? _Promise['default'] : _Promise;
 
 	var foo = 'foo';
 
-
+	_Promise.resolve( foo ).then( function ( foo ) {
+		console.log( foo );
+	});
 
 }));

--- a/test/bundle/output/umdDefaults/55.js
+++ b/test/bundle/output/umdDefaults/55.js
@@ -14,10 +14,10 @@
 		}
 	}
 
-	class B extends A {}
-
 	class C extends A {}
 
+	class B extends A {}
 
+	new A();
 
 }));

--- a/test/bundle/output/umdDefaults/55.js
+++ b/test/bundle/output/umdDefaults/55.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	class A {
 		b () {

--- a/test/bundle/output/umdDefaults/56.js
+++ b/test/bundle/output/umdDefaults/56.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 42;
 	var _foo = foo;

--- a/test/bundle/output/umdDefaults/56.js
+++ b/test/bundle/output/umdDefaults/56.js
@@ -10,6 +10,6 @@
 	foo += 1;
 	foo++;
 
-	console.log( _foo ); // 42
+	console.log( _foo );
 
 }));

--- a/test/bundle/output/umdDefaults/57.js
+++ b/test/bundle/output/umdDefaults/57.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = {
 		get y () { return x; }

--- a/test/bundle/output/umdDefaults/59.js
+++ b/test/bundle/output/umdDefaults/59.js
@@ -6,6 +6,6 @@
 
 	var foo = 'foo';
 
-	console.log( foo ); // 'foo'
+	console.log( foo );
 
 }));

--- a/test/bundle/output/umdDefaults/59.js
+++ b/test/bundle/output/umdDefaults/59.js
@@ -1,8 +1,8 @@
-(function (factory) {
-	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+(function (global, factory) {
+	typeof exports === 'object' && typeof module !== 'undefined' ? factory() :
 	typeof define === 'function' && define.amd ? define(factory) :
-	factory()
-}(function () { 'use strict';
+	factory();
+}(this, function () { 'use strict';
 
 	var foo = 'foo';
 

--- a/test/es6-module-transpiler-tests/input/duplicate-import-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/duplicate-import-fails/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	entry: 'importer',
-	expectedError: 'Duplicated import (\'a\')'
+	expectedError: 'Duplicated import \'a\''
 };

--- a/test/es6-module-transpiler-tests/input/duplicate-import-specifier-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/duplicate-import-specifier-fails/_config.js
@@ -1,4 +1,4 @@
 module.exports = {
 	entry: 'importer',
-	expectedError: 'Duplicated import (\'a\')'
+	expectedError: 'Duplicated import \'a\''
 };

--- a/test/es6-module-transpiler-tests/input/namespace-reassign-import-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/namespace-reassign-import-fails/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	entry: 'importer',	expectedError: 'Cannot reassign imported binding of namespace `exp`'
+	entry: 'importer',
+	expectedError: 'Illegal reassignment to import \'exp'\'
 };

--- a/test/es6-module-transpiler-tests/input/namespace-update-import-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/namespace-update-import-fails/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	entry: 'importer',	expectedError: 'Cannot reassign imported binding of namespace `exp`'
+	entry: 'importer'
+	expectedError: 'Illegal reassignment to import `exp`'
 };

--- a/test/es6-module-transpiler-tests/input/reassign-import-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/reassign-import-fails/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	entry: 'importer',	expectedError: 'Cannot reassign imported binding `x`'
+	entry: 'importer',
+	expectedError: 'Illegal reassignment to import \'x\''
 };

--- a/test/es6-module-transpiler-tests/input/reassign-import-not-at-top-level-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/reassign-import-not-at-top-level-fails/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	entry: 'importer',	expectedError: 'Cannot reassign imported binding `x`'
+	entry: 'importer'
+	expectedError: 'Illegal reassignment to import \'x\''
 };

--- a/test/es6-module-transpiler-tests/input/update-expression-of-import-fails/_config.js
+++ b/test/es6-module-transpiler-tests/input/update-expression-of-import-fails/_config.js
@@ -1,3 +1,4 @@
 module.exports = {
-	entry: 'importer',	expectedError: 'Cannot reassign imported binding `a`'
+	entry: 'importer',
+	expectedError: "Illegal reassignment to import 'a'"
 };

--- a/test/utils/makeWhitespaceVisible.js
+++ b/test/utils/makeWhitespaceVisible.js
@@ -1,5 +1,5 @@
 module.exports = function makeWhitespaceVisible ( str ) {
-	return str.replace( /\r?\n/g, '¶\n' ).replace( /^\t+/gm, function ( match ) {
+	return str.trim().replace( /\r?\n/g, '¶\n' ).replace( /^\t+/gm, function ( match ) {
 		// replace leading tabs
 		return match.replace( /\t/g, '--->' );
 	}).replace( /^( +)/gm, function ( match, $1 ) {


### PR DESCRIPTION
**not ready for merge**

Following #167 I started a separate project, [Rollup](http://github.com/rollup/rollup), which does a better job of bundling ES6 modules by only including the bits of code that are actually needed. Though it has a couple of known issues, I'm using it in a number of projects without problems.

Meanwhile Esperanto is continuing to rack up issues, and I don't have time to devote to maintaining two projects with basically the same goal. My intention here is to integrate Rollup into Esperanto (and remove all of Esperanto's bundling logic) so that we don't need to.

Before that can happen, Rollup needs a few features to be added and a few bugs (exposed by this process) to be fixed. That work is being tracked on https://github.com/rollup/rollup/pull/66.

Some changes that will fall out of this:

* Better interoperability. Esperanto's 'strict/non-strict' dichotomy doesn't exist in Rollup – importing the `default` from an external module will work whether it's an ES6 module or not. Exports from a bundle can be `default`, `named` or (unless otherwise specified) `auto`, which makes it easy to author ES6 bundles that play well with existing environments
* Self-executing bundles (Esperanto: `bundle.concat()`, Rollup: `bundle.generate({ format: 'iife' })`) can use external modules, if they're exposed to the global namespace. No need to generate UMD.
* `options.skip` is no longer supported. I've come to view this option as a mistake anyway – better to use a custom loader instead.
* Bundles will be smaller – in some cases, *much* smaller. Exposing Rollup to a wider audience through Esperanto may expose bugs in Rollup's bundling process, which is ultimately a good thing as long as it doesn't cause chaos in the meantime.

This doesn't affect one-to-one ES6 -> [AMD/CJS/UMD] conversions, only bundling. In future, it may make sense to remove bundling from Esperanto altogether, but this seemed like a more practical interim step.