### PR TITLE
Fix module id issue on Windows

### DIFF
--- a/src/bundler/getBundle.js
+++ b/src/bundler/getBundle.js
@@ -98,7 +98,7 @@ export default function getBundle ( options ) {
 				moduleLookup[ moduleId ] = module;
 
 				return promiseSequence( module.imports, x => {
-					const id = resolveId( x.path, module.path ).replace( base, '' );
+					const id = resolveId( x.path, module.path ).replace( base.replace(/\\/g, '/'), '' );
 
 					if ( id === moduleId ) {
 						throw new Error( `A module (${moduleId}) cannot import itself` );


### PR DESCRIPTION
`resolveId` explicitly uses `'/'` so base is not removed from the id on Windows, causing quite a few of the tests to fail on Windows and slight differences in bundle output between Mac and Windows.