### PR TITLE
Preserve comments after imports

### DIFF
--- a/src/bundler/getModule.js
+++ b/src/bundler/getModule.js
@@ -8,6 +8,7 @@ export default function getModule ( mod ) {
 	mod.body = new MagicString( mod.code );
 
 	let toRemove = [];
+	let comments = [];
 
 	try {
 		mod.ast = mod.ast || ( parse( mod.code, {
@@ -17,6 +18,8 @@ export default function getModule ( mod ) {
 				// sourceMappingURL comments should be removed
 				if ( !block && /^# sourceMappingURL=/.test( text ) ) {
 					toRemove.push({ start, end });
+				} else {
+					comments.push({ start, end });
 				}
 			}
 		}));
@@ -33,7 +36,7 @@ export default function getModule ( mod ) {
 	// remove sourceMappingURL comments
 	toRemove.forEach( ({ start, end }) => mod.body.remove( start, end ) );
 
-	let { imports, exports, defaultExport } = findImportsAndExports( mod.ast, mod.code );
+	let { imports, exports, defaultExport } = findImportsAndExports( mod.ast, mod.code, comments );
 
 	disallowConflictingImports( imports );
 

--- a/src/standalone/getModule.js
+++ b/src/standalone/getModule.js
@@ -20,6 +20,7 @@ export default function getStandaloneModule ( options ) {
 	}
 
 	let toRemove = [];
+	let comments = [];
 
 	let mod = {
 		body: new MagicString( code ),
@@ -30,6 +31,8 @@ export default function getStandaloneModule ( options ) {
 				// sourceMappingURL comments should be removed
 				if ( !block && SOURCEMAPPINGURL_REGEX.test( text ) ) {
 					toRemove.push({ start, end });
+				} else {
+					comments.push({ start, end });
 				}
 			}
 		}))
@@ -37,7 +40,7 @@ export default function getStandaloneModule ( options ) {
 
 	toRemove.forEach( ({ start, end }) => mod.body.remove( start, end ) );
 
-	let { imports, exports, defaultExport } = findImportsAndExports( mod.ast, code );
+	let { imports, exports, defaultExport } = findImportsAndExports( mod.ast, code, comments );
 
 	disallowConflictingImports( imports );
 

--- a/test/bundle/input/60/_config.js
+++ b/test/bundle/input/60/_config.js
@@ -1,0 +1,3 @@
+module.exports = {
+	description: 'preserves comments after imports'
+};

--- a/test/bundle/input/60/bar.js
+++ b/test/bundle/input/60/bar.js
@@ -1,0 +1,2 @@
+var bar = 'bar';
+export { bar };

--- a/test/bundle/input/60/foo.js
+++ b/test/bundle/input/60/foo.js
@@ -1,0 +1,2 @@
+var foo = 'foo';
+export { foo };

--- a/test/bundle/input/60/main.js
+++ b/test/bundle/input/60/main.js
@@ -1,0 +1,6 @@
+import { foo } from './foo';
+import { bar } from './bar';
+
+// Preserve comments after imports
+
+console.log( foo );

--- a/test/bundle/output/amd/22.js
+++ b/test/bundle/output/amd/22.js
@@ -8,6 +8,7 @@ define(['exports'], function (exports) {
 
 	exports.foo = foo;
 
+	// foo
 	foo();
 
 });

--- a/test/bundle/output/amd/52.js
+++ b/test/bundle/output/amd/52.js
@@ -8,6 +8,7 @@ define(function () {
 
 
 
+	// bar.js
 	console.log( 'baz', not_baz );
 
 

--- a/test/bundle/output/amd/60.js
+++ b/test/bundle/output/amd/60.js
@@ -1,0 +1,13 @@
+define(function () {
+
+	'use strict';
+
+	var foo = 'foo';
+
+	var bar = 'bar';
+
+	// Preserve comments after imports
+
+	console.log( foo );
+
+});

--- a/test/bundle/output/amdDefaults/52.js
+++ b/test/bundle/output/amdDefaults/52.js
@@ -8,6 +8,7 @@ define(function () {
 
 
 
+	// bar.js
 	console.log( 'baz', not_baz );
 
 

--- a/test/bundle/output/amdDefaults/60.js
+++ b/test/bundle/output/amdDefaults/60.js
@@ -1,0 +1,13 @@
+define(function () {
+
+	'use strict';
+
+	var foo = 'foo';
+
+	var bar = 'bar';
+
+	// Preserve comments after imports
+
+	console.log( foo );
+
+});

--- a/test/bundle/output/cjs/22.js
+++ b/test/bundle/output/cjs/22.js
@@ -6,4 +6,5 @@ function foo () {
 
 exports.foo = foo;
 
+// foo
 foo();

--- a/test/bundle/output/cjs/52.js
+++ b/test/bundle/output/cjs/52.js
@@ -6,5 +6,6 @@ var not_baz = function () {
 
 
 
+// bar.js
 console.log( 'baz', not_baz );
 

--- a/test/bundle/output/cjs/60.js
+++ b/test/bundle/output/cjs/60.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = 'foo';
+
+var bar = 'bar';
+
+// Preserve comments after imports
+
+console.log( foo );

--- a/test/bundle/output/cjsDefaults/52.js
+++ b/test/bundle/output/cjsDefaults/52.js
@@ -6,5 +6,6 @@ var not_baz = function () {
 
 
 
+// bar.js
 console.log( 'baz', not_baz );
 

--- a/test/bundle/output/cjsDefaults/60.js
+++ b/test/bundle/output/cjsDefaults/60.js
@@ -1,0 +1,9 @@
+'use strict';
+
+var foo = 'foo';
+
+var bar = 'bar';
+
+// Preserve comments after imports
+
+console.log( foo );

--- a/test/bundle/output/concat/52.js
+++ b/test/bundle/output/concat/52.js
@@ -6,6 +6,7 @@
 
 
 
+	// bar.js
 	console.log( 'baz', not_baz );
 
 

--- a/test/bundle/output/concat/60.js
+++ b/test/bundle/output/concat/60.js
@@ -1,0 +1,11 @@
+(function () { 'use strict';
+
+	var foo = 'foo';
+
+	var bar = 'bar';
+
+	// Preserve comments after imports
+
+	console.log( foo );
+
+})();

--- a/test/bundle/output/umd/22.js
+++ b/test/bundle/output/umd/22.js
@@ -10,6 +10,7 @@
 
 	exports.foo = foo;
 
+	// foo
 	foo();
 
 }));

--- a/test/bundle/output/umd/52.js
+++ b/test/bundle/output/umd/52.js
@@ -10,6 +10,7 @@
 
 
 
+	// bar.js
 	console.log( 'baz', not_baz );
 
 

--- a/test/bundle/output/umd/60.js
+++ b/test/bundle/output/umd/60.js
@@ -1,0 +1,15 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var foo = 'foo';
+
+	var bar = 'bar';
+
+	// Preserve comments after imports
+
+	console.log( foo );
+
+}));

--- a/test/bundle/output/umdDefaults/52.js
+++ b/test/bundle/output/umdDefaults/52.js
@@ -10,6 +10,7 @@
 
 
 
+	// bar.js
 	console.log( 'baz', not_baz );
 
 

--- a/test/bundle/output/umdDefaults/60.js
+++ b/test/bundle/output/umdDefaults/60.js
@@ -1,0 +1,15 @@
+(function (factory) {
+	!(typeof exports === 'object' && typeof module !== 'undefined') &&
+	typeof define === 'function' && define.amd ? define(factory) :
+	factory()
+}(function () { 'use strict';
+
+	var foo = 'foo';
+
+	var bar = 'bar';
+
+	// Preserve comments after imports
+
+	console.log( foo );
+
+}));


### PR DESCRIPTION
Updates `findImportsAndExports` to use next comment or node after imports, whichever is closest. Previously, it only looked for the next node after import, removing any comments that occurred in between.

Fixes #187